### PR TITLE
Use tempdir for MultiDocumenter output

### DIFF
--- a/docs/make_aggregate.jl
+++ b/docs/make_aggregate.jl
@@ -53,7 +53,7 @@ for (i, cat) in enumerate(docsmodules)
     push!(docs, MultiDocumenter.DropdownNav(cat[1], docsites))
 end
 
-outpath = joinpath(@__DIR__, "out")
+outpath = mktempdir()
 
 MultiDocumenter.make(
     outpath,


### PR DESCRIPTION
This needs to live outside of the repo, since we're switching to a different branch further down (which won't have the output dir we just generated).