### PR TITLE
enabled PreallocationTools docs in make_aggregate.jl

### DIFF
--- a/docs/make_aggregate.jl
+++ b/docs/make_aggregate.jl
@@ -55,7 +55,7 @@ docsmodules = [
 
     "Developer Tools" => [
     "Numerical Utilities" => ["ExponentialUtilities", "DiffEqNoiseProcess",
-        #="PreallocationTools",=# "EllipsisNotation",
+        "PreallocationTools", "EllipsisNotation",
         "PoissonRandom", "QuasiMonteCarlo", "RuntimeGeneratedFunctions", "MuladdMacro"],
     "Third-Party Numerical Utilities" => ["FFTW", #= "DataInterpolations",=# "Distributions",
                                           "SpecialFunctions", "LoopVectorization",


### PR DESCRIPTION
I removed the comments around `PreallocationTools` in the `make_aggregate.jl` file. 
This should pull the `PreallocationTools` docs into the full SciML Docs system.