### PR TITLE
manual sensealg in missing physics example

### DIFF
--- a/docs/src/showcase/missing_physics.md
+++ b/docs/src/showcase/missing_physics.md
@@ -195,10 +195,10 @@ function predict(θ, X = Xₙ[:, 1], T = t)
     _prob = remake(prob_nn, u0 = X, tspan = (T[1], T[end]), p = θ)
     Array(solve(_prob, Vern7(), saveat = T,
                 abstol = 1e-6, reltol = 1e-6, 
-                sensealg=ForwardDiffSensitivity()))
+                sensealg=QuadratureAdjoint(autojacvec=ReverseDiffVJP(true))))
 end
 ```
-There are many choices for the combination of sensitivity algorithm and automatic differentiation library (see [Choosing a Sensitivity Algorithm](https://docs.sciml.ai/SciMLSensitivity/stable/manual/differential_equation_sensitivities/#Choosing-a-Sensitivity-Algorithm). For example, you could have used `sensealg=QuadratureAdjoint(autojacvec=ReverseDiffVJP())`.
+There are many choices for the combination of sensitivity algorithm and automatic differentiation library (see [Choosing a Sensitivity Algorithm](https://docs.sciml.ai/SciMLSensitivity/stable/manual/differential_equation_sensitivities/#Choosing-a-Sensitivity-Algorithm). For example, you could have used `sensealg=ForwardDiffSensitivity()`.
 
 
 Now, for our loss function, we solve the ODE at our new parameters and check its L2 loss

--- a/docs/src/showcase/missing_physics.md
+++ b/docs/src/showcase/missing_physics.md
@@ -194,9 +194,12 @@ Knowing this, our `predict` function looks like:
 function predict(θ, X = Xₙ[:, 1], T = t)
     _prob = remake(prob_nn, u0 = X, tspan = (T[1], T[end]), p = θ)
     Array(solve(_prob, Vern7(), saveat = T,
-                abstol = 1e-6, reltol = 1e-6))
+                abstol = 1e-6, reltol = 1e-6, 
+                sensealg=ForwardDiffSensitivity()))
 end
 ```
+There are many choices for the combination of sensitivity algorithm and automatic differentiation library (see [Choosing a Sensitivity Algorithm](https://docs.sciml.ai/SciMLSensitivity/stable/manual/differential_equation_sensitivities/#Choosing-a-Sensitivity-Algorithm). For example, you could have used `sensealg=QuadratureAdjoint(autojacvec=ReverseDiffVJP())`.
+
 
 Now, for our loss function, we solve the ODE at our new parameters and check its L2 loss
 against the dataset. Using our `predict` function, this looks like:


### PR DESCRIPTION
This PR adds a manual `sensealg` argument to the missing physics example. Currently, increasing the number of parameters in the example (by i.e. increasing the size of the NN layers) causes Enzyme to be automatically selected as the AD backend. This causes issues, due to the relatively new Lux support for Enzyme (https://github.com/LuxDL/Lux.jl/issues/81). Eventually, this change can be reverted when Enzyme support matures.

I had put together an MVE for the errors in the missing_physics example, but it amounted basically to AD through a Lux prediction.

