### PR TITLE
ci: perform only shallow checkouts of the repository

### DIFF
--- a/.buildkite/aggregate.yml
+++ b/.buildkite/aggregate.yml
@@ -5,6 +5,12 @@ steps:
       BUILDKITE_PLUGIN_CRYPTIC_BASE64_SIGNED_JOB_ID_SECRET: ${BUILDKITE_PLUGIN_CRYPTIC_BASE64_SIGNED_JOB_ID_SECRET?}
 
     plugins:
+      - hasura/smooth-checkout#v4.4.1:
+          repos:
+            - config:
+                - url: "https://github.com/SciML/SciMLDocs.git"
+                  clone_flags: "--depth=1"
+
       - staticfloat/cryptic#v2:
           variables:
             - AWS_ACCESS_KEY_ID="U2FsdGVkX18h85CJAJTEJ8zXd7CrctZHYX4n/yM2xL9uXO0kgRE/kJr8vEHnOOV1"

--- a/.buildkite/aggregate.yml.signature
+++ b/.buildkite/aggregate.yml.signature
@@ -1,1 +1,1 @@
-Salted__ˆÖÕt†3Òº«>¹-Á™oYAïGB˜NýÙXŠ†¨«1änéÙ¸øô¾»Ø¨|@þ74–BÞ3q¹‘Âä…<Rw©Ç]jê%¸Œe`¾vj½r;@Q!
+Salted__Œ¢CeNFmÔÈA{2KJÚ5¹«Ïd0o\ñD@D{]$Š%Îèò'i¶Xúj'|G$ˆÂûŽ‹9VŠ àA‰U]Œè7&yã0›•q\{ÙWåùk´7

--- a/.buildkite/documentation.yml
+++ b/.buildkite/documentation.yml
@@ -3,7 +3,15 @@ steps:
     plugins:
       - JuliaCI/julia#v1:
           version: "1"
+      - hasura/smooth-checkout#v4.4.1:
+          repos:
+            - config:
+                - url: "https://github.com/SciML/SciMLDocs.git"
+                  clone_flags: "--depth=1"
+
     command: |
+      git remote set-branches origin 'gh-pages'
+      git fetch --depth=1 origin gh-pages
       julia --project -e '
         println("--- :julia: Instantiating project")
         using Pkg


### PR DESCRIPTION
Given the size of the repository, we spend an inordinate time in CI for each step just cloning the repository (sometimes upto ~7 mins[^1]); an inefficiency that is obviously problematic.
Fix this, by performing only a shallow checkout of the repository using the `hasura/smooth-checkout` plugin. The steps defined in the WebUI have also been updated to do the same. This brings down the repository checkout time significantly, to just 1-2s[^2].

Since the documentation workflow will require switching branches and pushing to the repository, additionally fetch just the `HEAD` of `gh-pages` in that workflow before actually building and trying to deploy the documentation.

[^1]: https://buildkite.com/julialang/scimldocs/builds/2955#018bdc82-534f-4aa9-8e3e-00865db3fa22/56
[^2]: https://buildkite.com/julialang/scimldocs/builds/2961#018bdcc2-45f7-45a2-b600-8cff02d2360b/101