### PR TITLE
Do not rehost third party docs of non-SciML packages

### DIFF
--- a/docs/make_aggregate.jl
+++ b/docs/make_aggregate.jl
@@ -16,63 +16,32 @@ docsmodules = [
             "BaseModelica",
             "ReactionNetworkImporters"],
         "Symbolic Tools" => ["ModelOrderReduction", "Symbolics", "SymbolicUtils"], #="MetaTheory"=#
-        "Third-Party Modeling Tools" => ["MomentClosure", "Agents", "Unitful",
-            "ReactionMechanismSimulator",
-            "AlgebraicPetri"],
         "Array Libraries" => ["RecursiveArrayTools", "LabelledArrays", "MultiScaleArrays"],
-        "Third-Party Array Libraries" => ["ComponentArrays", "StaticArrays", #="FillArrays",=#
-            "BandedMatrices", "BlockBandedMatrices"],
     ],
     "Solvers" => [
         "Equation Solvers" => ["LinearSolve", "NonlinearSolve", "DiffEqDocs", "Integrals", "DifferenceEquations",
             "Optimization", "JumpProcesses"],
-        "Third-Party Equation Solvers" => [
-            "LowRankIntegrators",
-            "FractionalDiffEq",
-            "ManifoldDiffEq",
-        ],
         "Inverse Problems / Estimation" => [
             "SciMLSensitivity", "DiffEqParamEstim", "DiffEqBayes"],
         "PDE Solvers" => ["MethodOfLines", "NeuralPDE",
             "NeuralOperators", "FEniCS",
             "HighDimPDE", "DiffEqOperators"],
-        "Third-Party PDE Solvers" => [
-            "Trixi",
-            "Ferrite",
-            "Gridap",
-            "ApproxFun",
-            "VoronoiFVM",
-        ],
         "Advanced Solver APIs" => ["OrdinaryDiffEq", "DiffEqGPU"],
     ],
     "Analysis" => [
         "Plots and Visualization" => ["Makie"], #="PlotDocs",=#
         "Parameter Analysis" => ["EasyModelAnalysis", "GlobalSensitivity", "StructuralIdentifiability"],
-        "Third-Party Parameter Analysis" => ["DynamicalSystems", "BifurcationKit",
-            "ControlSystems", "ReachabilityAnalysis"],
         "Uncertainty Quantification" => ["PolyChaos", "SciMLExpectations"],
-        "Third-Party Uncertainty Quantification" => ["Measurements",
-            "MonteCarloMeasurements",
-            "ProbNumDiffEq", "TaylorIntegration",
-            "IntervalArithmetic"],
     ],
     "Machine Learning" => [
         "Function Approximation" => ["Surrogates", "ReservoirComputing"],
         "Implicit Layer Deep Learning" => ["DiffEqFlux", "DeepEquilibriumNetworks"],
-        "Third-Party Implicit Layer Deep Learning" => ["Flux", "Lux", "SimpleChains"],
         "Symbolic Learning" => ["DataDrivenDiffEq", "SymbolicNumericIntegration"],
-        "Third-Party Symbolic Learning" => ["SymbolicRegression"],
-        "Third-Party Differentiation Tooling" => ["SparseDiffTools", "FiniteDiff",
-            "ForwardDiff",
-            "Zygote", "Enzyme"],
     ],
     "Developer Tools" => [
         "Numerical Utilities" => ["ExponentialUtilities", "DiffEqNoiseProcess",
             "PreallocationTools", "EllipsisNotation", "DataInterpolations",
             "PoissonRandom", "QuasiMonteCarlo", "RuntimeGeneratedFunctions", "MuladdMacro", "FindFirstFunctions"],
-        "Third-Party Numerical Utilities" => ["FFTW", "Distributions",
-            "SpecialFunctions", "LoopVectorization",
-            "Polyester", "SparseDiffTools"], #="Tullio"=#
         "High-Level Interfaces" => [
             "SciMLBase",
             "SciMLStructures",
@@ -82,9 +51,6 @@ docsmodules = [
             "SurrogatesBase",
             "CommonSolve",
         ],
-        "Third-Party Interfaces" => ["ArrayInterface", "StaticArrayInterface", "AbstractFFTs", 
-            "GPUArrays", #= "Adapt", =#
-            "Tables"],                                 #= "RecipesBase", =#
         "Developer Documentation" => ["SciMLStyle", "ColPrac", "DiffEqDevDocs"],
         "Extra Resources" => [
             "SciMLWorkshop",
@@ -98,66 +64,10 @@ docsmodules = [
 fixnames = Dict("SciMLDocs" => "The SciML Open Source Software Ecosystem",
                 "DiffEqDocs" => "DifferentialEquations",
                 "DiffEqDevDocs" => "DiffEq Developer Documentation",
-                "PlotDocs" => "Plots",
                 "SciMLBenchmarksOutput" => "The SciML Benchmarks",
                 "SciMLTutorialsOutput" => "Extended SciML Tutorials")
 hasnojl = ["SciMLBenchmarksOutput", "SciMLTutorialsOutput", "ColPrac", "SciMLStyle", "ModelingToolkitCourse"]
 usemain = ["SciMLBenchmarksOutput", "SciMLTutorialsOutput"]
-
-external_urls = Dict("Enzyme" => "https://github.com/EnzymeAD/Enzyme.jl",
-                     "Zygote" => "https://github.com/FluxML/Zygote.jl",
-                     "FiniteDiff" => "https://github.com/JuliaDiff/FiniteDiff.jl",
-                     "ForwardDiff" => "https://github.com/JuliaDiff/ForwardDiff.jl",
-                     "SparseDiffTools" => "https://github.com/JuliaDiff/SparseDiffTools.jl",
-                     "ManifoldDiffEq" => "https://github.com/JuliaManifolds/ManifoldDiffEq.jl",
-                     "FractionalDiffEq" => "https://github.com/SciFracX/FractionalDiffEq.jl",
-                     "Agents" => "https://github.com/JuliaDynamics/Agents.jl",
-                     "LowRankIntegrators" => "https://github.com/FHoltorf/LowRankIntegrators.jl",
-                     "MomentClosure" => "https://github.com/augustinas1/MomentClosure.jl",
-                     "Trixi" => "https://github.com/trixi-framework/Trixi.jl",
-                     "Gridap" => "https://github.com/gridap/Gridap.jl",
-                     "Ferrite" => "https://github.com/Ferrite-FEM/Ferrite.jl",
-                     "ApproxFun" => "https://github.com/JuliaApproximation/ApproxFun.jl",
-                     "VoronoiFVM" => "https://github.com/j-fu/VoronoiFVM.jl",
-                     "Symbolics" => "https://github.com/JuliaSymbolics/Symbolics.jl",
-                     "SymbolicUtils" => "https://github.com/JuliaSymbolics/SymbolicUtils.jl",
-                     "TermInterface" => "https://github.com/JuliaSymbolics/TermInterface.jl",
-                     "ComponentArrays" => "https://github.com/jonniedie/ComponentArrays.jl",
-                     "StaticArrays" => "https://github.com/JuliaArrays/StaticArrays.jl",
-                     "FillArrays" => "https://github.com/JuliaArrays/FillArrays.jl",
-                     "BandedMatrices" => "https://github.com/JuliaMatrices/BandedMatrices.jl",
-                     "BlockBandedMatrices" => "https://github.com/JuliaMatrices/BlockBandedMatrices.jl",
-                     "PlotDocs" => "https://github.com/JuliaPlots/PlotDocs.jl",
-                     "Makie" => "https://github.com/MakieOrg/Makie.jl",
-                     "Measurements" => "https://github.com/JuliaPhysics/Measurements.jl",
-                     "MonteCarloMeasurements" => "https://github.com/baggepinnen/MonteCarloMeasurements.jl",
-                     "ProbNumDiffEq" => "https://github.com/nathanaelbosch/ProbNumDiffEq.jl",
-                     "TaylorIntegration" => "https://github.com/PerezHz/TaylorIntegration.jl",
-                     "IntervalArithmetic" => "https://github.com/JuliaIntervals/IntervalArithmetic.jl",
-                     "DynamicalSystems" => "https://github.com/JuliaDynamics/DynamicalSystems.jl",
-                     "BifurcationKit" => "https://github.com/bifurcationkit/BifurcationKitDocs.jl",
-                     "ReachabilityAnalysis" => "https://github.com/JuliaReach/ReachabilityAnalysis.jl",
-                     "ControlSystems" => "https://github.com/JuliaControl/ControlSystems.jl",
-                     "Flux" => "https://github.com/FluxML/Flux.jl",
-                     "Lux" => "https://github.com/LuxDL/Lux.jl",
-                     "SimpleChains" => "https://github.com/PumasAI/SimpleChains.jl",
-                     "NNlib" => "https://github.com/FluxML/NNlib.jl",
-                     "SymbolicRegression" => "https://github.com/MilesCranmer/SymbolicRegression.jl",
-                     "FFTW" => "https://github.com/JuliaMath/FFTW.jl",
-                     "Distributions" => "https://github.com/JuliaStats/Distributions.jl",
-                     "SpecialFunctions" => "https://github.com/JuliaMath/SpecialFunctions.jl",
-                     "LoopVectorization" => "https://github.com/JuliaSIMD/LoopVectorization.jl",
-                     "Polyester" => "https://github.com/JuliaSIMD/Polyester.jl",
-                     "Tullio" => "https://github.com/mcabbott/Tullio.jl",
-                     "ArrayInterface" => "https://github.com/JuliaArrays/ArrayInterface.jl",
-                     "StaticArrayInterface" => "https://github.com/JuliaArrays/StaticArrayInterface.jl",
-                     "AbstractFFTs" => "https://github.com/JuliaMath/AbstractFFTs.jl",
-                     "GPUArrays" => "https://github.com/JuliaGPU/GPUArrays.jl",
-                     "Tables" => "https://github.com/JuliaData/Tables.jl",
-                     "Unitful" => "https://github.com/PainterQubits/Unitful.jl",
-                     "ReactionMechanismSimulator" => "https://github.com/ReactionMechanismGenerator/ReactionMechanismSimulator.jl",
-                     "FiniteStateProjection" => "https://github.com/kaandocal/FiniteStateProjection.jl",
-                     "AlgebraicPetri" => "https://github.com/AlgebraicJulia/AlgebraicPetri.jl")
 
 docs = Any[MultiDocumenter.MultiDocRef(upstream = joinpath(clonedir, "Home"),
                                        path = "Overview",
@@ -171,8 +81,6 @@ for group in docsmodules
         for mod in cat[2]
             url = if mod in hasnojl
                 "https://github.com/SciML/$mod.git"
-            elseif mod in keys(external_urls)
-                external_urls[mod]
             else
                 "https://github.com/SciML/$mod.jl.git"
             end


### PR DESCRIPTION
Fixes #151.

The PR removes the rehosted documentation of non-SciML packages. Currently, the SciML rehosts a huge number of external docs. If the SciML docs want to refer to them, they should link to these but not copy them, even more so since I assume typically this happens without the consent of these third party packages. The external packages already host their docs but it seems in some cases Google already ranks the SciML docs higher (even though the SciML copy is generally outdated since updates of the third party docs are not automatically pushed to the SciML docs). In some cases (e.g. Lux) that do not use the standard Documenter layout, the rehosted copy is also completely broken: https://docs.sciml.ai/Lux/stable/

IMO the fact that MultiDocumenter has no support for linking to other docs in the top bar is no reason to keep rehosting the third party docs. The current behaviour is just plain wrong, it violates the preference and possibly even license of external packages and is done without consent.