### PR TITLE
Fix description in Optimization under Uncertainty showcase

### DIFF
--- a/docs/src/showcase/optimization_under_uncertainty.md
+++ b/docs/src/showcase/optimization_under_uncertainty.md
@@ -113,7 +113,7 @@ sol.u
 
 ## Optimization Under Uncertainty
 
-We now wish to optimize the initial position ($x_0,y_0$) and horizontal velocity ($\dot{x}_0$) of the system to minimize the expected squared miss distance from the star, where $x_0\in\left[-100,0\right]$, $y_0\in\left[1,3\right]$, and $\dot{x}_0\in\left[10,50\right]$. We will demonstrate this using a gradient-based optimization approach from NLopt.jl using `ForwardDiff.jl` AD through the expectation calculation.
+We now wish to optimize the initial position ($x_0,y_0$) and horizontal velocity ($\dot{x}_0$) of the system to minimize the expected squared miss distance from the star, where $x_0\in\left[-100,0\right]$, $\dot{x}_0\in\left[1,3\right]$, and $y_0\in\left[10,50\right]$. We will demonstrate this using a gradient-based optimization approach from NLopt.jl using `ForwardDiff.jl` AD through the expectation calculation.
 
 ```@example control
 using Optimization, OptimizationNLopt, OptimizationMOI


### PR DESCRIPTION
The description of the bounds on the initial conditions in the Optimization under Uncertainty showcase was wrong (discovered by seeing that the ball starts at around y = 50). 

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
