### PR TITLE
use benchmark not btime in brusselator example

### DIFF
--- a/docs/src/showcase/brusselator.md
+++ b/docs/src/showcase/brusselator.md
@@ -252,15 +252,17 @@ assess this performance difference:
 
 ```@example bruss
 using BenchmarkTools
-@btime sol = solve(prob, TRBDF2(), saveat = 0.1);
-@btime sol = solve(prob_sparse, TRBDF2(), saveat = 0.1);
+@benchmark sol = solve(prob, TRBDF2(), saveat = 0.1);
+```
+```@example bruss
+@benchmark sol = solve(prob_sparse, TRBDF2(), saveat = 0.1);
 ```
 
 But we can further improve this as well. Instead of just using the default linear solver,
 we can change this to a Newton-Krylov method by passing in the GMRES method:
 
 ```@example bruss
-@btime sol = solve(prob_sparse, TRBDF2(linsolve = KrylovJL_GMRES()), saveat = 0.1);
+@benchmark sol = solve(prob_sparse, TRBDF2(linsolve = KrylovJL_GMRES()), saveat = 0.1);
 ```
 
 But to further improve performance, we can use an iLU preconditioner. This looks like
@@ -277,7 +279,7 @@ function incompletelu(W, du, u, p, t, newW, Plprev, Prprev, solverdata)
     Pl, nothing
 end
 
-@btime solve(prob_sparse,
+@benchmark solve(prob_sparse,
     TRBDF2(linsolve = KrylovJL_GMRES(), precs = incompletelu, concrete_jac = true),
     save_everystep = false);
 ```


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
