### PR TITLE
Switch from JuliaFormatter to Runic.jl for code formatting

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,2 +1,0 @@
-style = "sciml"
-format_markdown = true

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,0 +1,19 @@
+name: format-check
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'main'
+      - 'release-'
+    tags: '*'
+  pull_request:
+
+jobs:
+  runic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: fredrikekre/runic-action@v1
+        with:
+          version: '1'

--- a/docs/CommercialSupportComponent.jl
+++ b/docs/CommercialSupportComponent.jl
@@ -1,4 +1,4 @@
-struct JuliaHubCommercialSupportComponent <: MultiDocumenter.DropdownComponent 
+struct JuliaHubCommercialSupportComponent <: MultiDocumenter.DropdownComponent
     link::String
 end
 
@@ -13,7 +13,7 @@ function MultiDocumenter.render(c::JuliaHubCommercialSupportComponent, doc, this
         <a href="$(c.link)" class="nav-link nav-item">JuliaHub offers commercial support for ModelingToolkit and the SciML ecosystem.  Contact us today to discuss your needs!</a>
     </div>
     """
-    
+
 end
 
 struct ProductsUsedComponent <: MultiDocumenter.DropdownComponent end
@@ -27,13 +27,15 @@ PRODUCTNAME_IMAGE_LINK = [
 ]
 
 function MultiDocumenter.render(c::ProductsUsedComponent, doc, thispage, prettyurls)
-    strings = [MultiDocumenter.@htl """
-    <li>
-        <a href=$(product.link) class="nav-link nav-item">
-            $(product.product)
-        </a>
-    </li>
-    """ for product in PRODUCTNAME_IMAGE_LINK]
+    strings = [
+        MultiDocumenter.@htl """
+            <li>
+                <a href=$(product.link) class="nav-link nav-item">
+                    $(product.product)
+                </a>
+            </li>
+            """ for product in PRODUCTNAME_IMAGE_LINK
+    ]
 
     return MultiDocumenter.@htl """
     <table>

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -7,21 +7,29 @@ cp("./docs/Project.toml", "./docs/src/assets/Project.toml", force = true)
 ENV["GKSwstype"] = "100"
 using Plots
 
-mathengine = MathJax3(Dict(:loader => Dict("load" => ["[tex]/require", "[tex]/mathtools"]),
-    :tex => Dict("inlineMath" => [["\$", "\$"], ["\\(", "\\)"]],
-        "packages" => [
-            "base",
-            "ams",
-            "autoload",
-            "mathtools",
-            "require"
-        ])))
+mathengine = MathJax3(
+    Dict(
+        :loader => Dict("load" => ["[tex]/require", "[tex]/mathtools"]),
+        :tex => Dict(
+            "inlineMath" => [["\$", "\$"], ["\\(", "\\)"]],
+            "packages" => [
+                "base",
+                "ams",
+                "autoload",
+                "mathtools",
+                "require",
+            ]
+        )
+    )
+)
 
-makedocs(sitename = "Overview of Julia's SciML",
+makedocs(
+    sitename = "Overview of Julia's SciML",
     authors = "Chris Rackauckas",
     modules = Module[],
     clean = true, doctest = false, linkcheck = true,
-    linkcheck_ignore = ["https://twitter.com/ChrisRackauckas/status/1477274812460449793",
+    linkcheck_ignore = [
+        "https://twitter.com/ChrisRackauckas/status/1477274812460449793",
         "https://epubs.siam.org/doi/10.1137/0903023",
         "https://bkamins.github.io/julialang/2020/12/24/minilanguage.html",
         "https://arxiv.org/abs/2109.06786",
@@ -31,11 +39,13 @@ makedocs(sitename = "Overview of Julia's SciML",
         "https://github.com/JuliaDiff/ForwardDiff.jl/blob/master/docs/src/dev/how_it_works.md",
         "https://github.com/SciML/Optimization.jl/blob/master/lib/OptimizationPolyalgorithms/src/OptimizationPolyalgorithms.jl",
         "http://www.scholarpedia.org/article/Differential-algebraic_equations",
-        "https://computing.llnl.gov/projects/sundials"
-        ],
-    format = Documenter.HTML(assets = ["assets/favicon.ico"],
+        "https://computing.llnl.gov/projects/sundials",
+    ],
+    format = Documenter.HTML(
+        assets = ["assets/favicon.ico"],
         canonical = "https://docs.sciml.ai/stable/",
-        mathengine = mathengine),
+        mathengine = mathengine
+    ),
     pages = [
         "SciML: Open Source Software for Scientific Machine Learning with Julia" => "index.md",
         "Getting Started" => [
@@ -45,46 +55,66 @@ makedocs(sitename = "Overview of Julia's SciML",
                 "getting_started/first_simulation.md",
                 "getting_started/first_optimization.md",
                 "getting_started/fit_simulation.md",
-                "getting_started/find_root.md"
+                "getting_started/find_root.md",
             ],
             "Comparison With Other Tools" => [
                 "comparisons/python.md",
                 "comparisons/matlab.md",
                 "comparisons/r.md",
-                "comparisons/cppfortran.md"
-            ]
+                "comparisons/cppfortran.md",
+            ],
         ],
-        "Showcase of Cool Examples" => Any["showcase/showcase.md",
-            "Automated Model Discovery" => Any["showcase/missing_physics.md",
+        "Showcase of Cool Examples" => Any[
+            "showcase/showcase.md",
+            "Automated Model Discovery" => Any[
+                "showcase/missing_physics.md",
                 "showcase/bayesian_neural_ode.md",
                 "showcase/optimal_data_gathering_for_missing_physics.md",
-                "showcase/blackhole.md"],
-            "Solving Difficult Equations Efficiently" => Any["showcase/brusselator.md",
+                "showcase/blackhole.md",
+            ],
+            "Solving Difficult Equations Efficiently" => Any[
+                "showcase/brusselator.md",
                 "showcase/pinngpu.md",
                 "showcase/massively_parallel_gpu.md",
-                "showcase/gpu_spde.md"],
-            "Useful Cool Wonky Things" => Any["showcase/ode_types.md",
+                "showcase/gpu_spde.md",
+            ],
+            "Useful Cool Wonky Things" => Any[
+                "showcase/ode_types.md",
                 "showcase/symbolic_analysis.md",
-                "showcase/optimization_under_uncertainty.md"]],
-        "What is SciML?" => ["overview.md",
-            "Solvers" => ["highlevels/equation_solvers.md",
+                "showcase/optimization_under_uncertainty.md",
+            ],
+        ],
+        "What is SciML?" => [
+            "overview.md",
+            "Solvers" => [
+                "highlevels/equation_solvers.md",
                 "highlevels/inverse_problems.md",
-                "highlevels/partial_differential_equation_solvers.md"],
-            "Modeling Tools" => ["highlevels/modeling_languages.md",
+                "highlevels/partial_differential_equation_solvers.md",
+            ],
+            "Modeling Tools" => [
+                "highlevels/modeling_languages.md",
                 "highlevels/model_libraries_and_importers.md",
                 "highlevels/symbolic_tools.md",
-                "highlevels/array_libraries.md"],
-            "Simulation Analysis" => ["highlevels/parameter_analysis.md",
+                "highlevels/array_libraries.md",
+            ],
+            "Simulation Analysis" => [
+                "highlevels/parameter_analysis.md",
                 "highlevels/uncertainty_quantification.md",
-                "highlevels/plots_visualization.md"],
-            "Machine Learning" => ["highlevels/function_approximation.md",
+                "highlevels/plots_visualization.md",
+            ],
+            "Machine Learning" => [
+                "highlevels/function_approximation.md",
                 "highlevels/implicit_layers.md",
-                "highlevels/symbolic_learning.md"],
-            "Developer Tools" => ["highlevels/numerical_utilities.md",
+                "highlevels/symbolic_learning.md",
+            ],
+            "Developer Tools" => [
+                "highlevels/numerical_utilities.md",
                 "highlevels/interfaces.md",
-                "highlevels/developer_documentation.md"],
-            "Extra Learning Resources" => ["highlevels/learning_resources.md"]
-        ]],
+                "highlevels/developer_documentation.md",
+            ],
+            "Extra Learning Resources" => ["highlevels/learning_resources.md"],
+        ],
+    ],
 )
 
 deploydocs(repo = "github.com/SciML/SciMLDocs")

--- a/docs/make_aggregate.jl
+++ b/docs/make_aggregate.jl
@@ -8,15 +8,19 @@ clonedir = joinpath(@__DIR__, "cloned")
 # Ordering Matters!
 docsmodules = [
     "Modeling" => [
-        "Modeling Languages" => ["ModelingToolkit", "Catalyst", "NBodySimulator",
-            "ParameterizedFunctions"],
-        "Model Libraries and Importers" => ["ModelingToolkitStandardLibrary",
+        "Modeling Languages" => [
+            "ModelingToolkit", "Catalyst", "NBodySimulator",
+            "ParameterizedFunctions",
+        ],
+        "Model Libraries and Importers" => [
+            "ModelingToolkitStandardLibrary",
             "ModelingToolkitNeuralNets",
             "DiffEqCallbacks",
             "FiniteStateProjection",
             "CellMLToolkit", "SBMLToolkit",
             "BaseModelica",
-            "ReactionNetworkImporters"],
+            "ReactionNetworkImporters",
+        ],
         "Symbolic Tools" => ["ModelOrderReduction", "Symbolics", "SymbolicUtils", "SymbolicIntegration", "SymbolicSMT", "SymbolicLimits", "SymbolicAnalysis"], #="MetaTheory"=#
         #=
         "Third-Party Modeling Tools" => ["MomentClosure", "Agents", "Unitful",
@@ -32,7 +36,8 @@ docsmodules = [
     "Solvers" => [
         "Equation Solvers" => [
             "LinearSolve", "NonlinearSolve", "DiffEqDocs", "Integrals",
-            "DifferenceEquations", "Optimization", "JumpProcesses", "LineSearch"],
+            "DifferenceEquations", "Optimization", "JumpProcesses", "LineSearch",
+        ],
         #=
         "Third-Party Equation Solvers" => [
             "LowRankIntegrators",
@@ -41,10 +46,13 @@ docsmodules = [
         ],
         =#
         "Inverse Problems / Estimation" => [
-            "SciMLSensitivity", "DiffEqParamEstim", "DiffEqBayes"],
-        "PDE Solvers" => ["MethodOfLines", "NeuralPDE",
+            "SciMLSensitivity", "DiffEqParamEstim", "DiffEqBayes",
+        ],
+        "PDE Solvers" => [
+            "MethodOfLines", "NeuralPDE",
             "NeuralOperators", "FEniCS",
-            "HighDimPDE", "DiffEqOperators"],
+            "HighDimPDE", "DiffEqOperators",
+        ],
         #=
         "Third-Party PDE Solvers" => [
             "Trixi",
@@ -75,15 +83,19 @@ docsmodules = [
         #= "Third-Party Implicit Layer Deep Learning" => ["Flux", "Lux", "SimpleChains"], =#
         "Symbolic Learning" => ["DataDrivenDiffEq", "SymbolicNumericIntegration"],
         #= "Third-Party Symbolic Learning" => ["SymbolicRegression"], =#
-        "Third-Party Differentiation Tooling" => ["SparseDiffTools", "FiniteDiff",
+        "Third-Party Differentiation Tooling" => [
+            "SparseDiffTools", "FiniteDiff",
             #= "ForwardDiff",
-            "Zygote", "Enzyme" =#],
+            "Zygote", "Enzyme" =#
+        ],
     ],
     "Developer Tools" => [
-        "Numerical Utilities" => ["ExponentialUtilities", "DiffEqNoiseProcess",
+        "Numerical Utilities" => [
+            "ExponentialUtilities", "DiffEqNoiseProcess",
             "PreallocationTools", "EllipsisNotation", "DataInterpolations", "NDInterpolations",
             "PoissonRandom", "QuasiMonteCarlo", "RuntimeGeneratedFunctions", "MuladdMacro", "FindFirstFunctions",
-            "SparseDiffTools", "BipartiteGraphs"],
+            "SparseDiffTools", "BipartiteGraphs",
+        ],
         #=
         "Third-Party Numerical Utilities" => ["FFTW", "Distributions",
             "SpecialFunctions", "LoopVectorization",
@@ -100,7 +112,7 @@ docsmodules = [
             "SurrogatesBase",
             "CommonSolve",
         ],
-        "Third-Party Interfaces" => ["ArrayInterface", "StaticArrayInterface", #= "AbstractFFTs",
+        "Third-Party Interfaces" => ["ArrayInterface", "StaticArrayInterface" #= "AbstractFFTs",
             "GPUArrays", #= "Adapt", =#
             "Tables" =#],                                 #= "RecipesBase", =#
         "Developer Documentation" => ["SciMLStyle", "ColPrac", "DiffEqDevDocs"],
@@ -113,75 +125,83 @@ docsmodules = [
     ],
 ]
 
-fixnames = Dict("SciMLDocs" => "The SciML Open Source Software Ecosystem",
-                "DiffEqDocs" => "DifferentialEquations",
-                "DiffEqDevDocs" => "DiffEq Developer Documentation",
-                "PlotDocs" => "Plots",
-                "SciMLBenchmarksOutput" => "The SciML Benchmarks",
-                "SciMLTutorialsOutput" => "Extended SciML Tutorials")
+fixnames = Dict(
+    "SciMLDocs" => "The SciML Open Source Software Ecosystem",
+    "DiffEqDocs" => "DifferentialEquations",
+    "DiffEqDevDocs" => "DiffEq Developer Documentation",
+    "PlotDocs" => "Plots",
+    "SciMLBenchmarksOutput" => "The SciML Benchmarks",
+    "SciMLTutorialsOutput" => "Extended SciML Tutorials"
+)
 hasnojl = ["SciMLBenchmarksOutput", "SciMLTutorialsOutput", "ColPrac", "SciMLStyle", "ModelingToolkitCourse"]
 usemain = ["SciMLBenchmarksOutput", "SciMLTutorialsOutput"]
 
-external_urls = Dict("Enzyme" => "https://github.com/EnzymeAD/Enzyme.jl",
-                     "Zygote" => "https://github.com/FluxML/Zygote.jl",
-                     "FiniteDiff" => "https://github.com/JuliaDiff/FiniteDiff.jl",
-                     "ForwardDiff" => "https://github.com/JuliaDiff/ForwardDiff.jl",
-                     "SparseDiffTools" => "https://github.com/JuliaDiff/SparseDiffTools.jl",
-                     "ManifoldDiffEq" => "https://github.com/JuliaManifolds/ManifoldDiffEq.jl",
-                     "FractionalDiffEq" => "https://github.com/SciFracX/FractionalDiffEq.jl",
-                     "Agents" => "https://github.com/JuliaDynamics/Agents.jl",
-                     "LowRankIntegrators" => "https://github.com/FHoltorf/LowRankIntegrators.jl",
-                     "MomentClosure" => "https://github.com/augustinas1/MomentClosure.jl",
-                     "Trixi" => "https://github.com/trixi-framework/Trixi.jl",
-                     "Gridap" => "https://github.com/gridap/Gridap.jl",
-                     "Ferrite" => "https://github.com/Ferrite-FEM/Ferrite.jl",
-                     "ApproxFun" => "https://github.com/JuliaApproximation/ApproxFun.jl",
-                     "VoronoiFVM" => "https://github.com/j-fu/VoronoiFVM.jl",
-                     "Symbolics" => "https://github.com/JuliaSymbolics/Symbolics.jl",
-                     "SymbolicSMT" => "https://github.com/JuliaSymbolics/SymbolicSMT.jl",
-                     "SymbolicIntegration" => "https://github.com/JuliaSymbolics/SymbolicIntegration.jl",
-                     "SymbolicUtils" => "https://github.com/JuliaSymbolics/SymbolicUtils.jl",
-                     "TermInterface" => "https://github.com/JuliaSymbolics/TermInterface.jl",
-                     "StaticArrays" => "https://github.com/JuliaArrays/StaticArrays.jl",
-                     "FillArrays" => "https://github.com/JuliaArrays/FillArrays.jl",
-                     "BandedMatrices" => "https://github.com/JuliaMatrices/BandedMatrices.jl",
-                     "BlockBandedMatrices" => "https://github.com/JuliaMatrices/BlockBandedMatrices.jl",
-                     "PlotDocs" => "https://github.com/JuliaPlots/PlotDocs.jl",
-                     "Makie" => "https://github.com/MakieOrg/Makie.jl",
-                     "Measurements" => "https://github.com/JuliaPhysics/Measurements.jl",
-                     "MonteCarloMeasurements" => "https://github.com/baggepinnen/MonteCarloMeasurements.jl",
-                     "ProbNumDiffEq" => "https://github.com/nathanaelbosch/ProbNumDiffEq.jl",
-                     "TaylorIntegration" => "https://github.com/PerezHz/TaylorIntegration.jl",
-                     "IntervalArithmetic" => "https://github.com/JuliaIntervals/IntervalArithmetic.jl",
-                     "DynamicalSystems" => "https://github.com/JuliaDynamics/DynamicalSystems.jl",
-                     "BifurcationKit" => "https://github.com/bifurcationkit/BifurcationKitDocs.jl",
-                     "ReachabilityAnalysis" => "https://github.com/JuliaReach/ReachabilityAnalysis.jl",
-                     "ControlSystems" => "https://github.com/JuliaControl/ControlSystems.jl",
-                     "Flux" => "https://github.com/FluxML/Flux.jl",
-                     "Lux" => "https://github.com/LuxDL/Lux.jl",
-                     "SimpleChains" => "https://github.com/PumasAI/SimpleChains.jl",
-                     "NNlib" => "https://github.com/FluxML/NNlib.jl",
-                     "SymbolicRegression" => "https://github.com/MilesCranmer/SymbolicRegression.jl",
-                     "FFTW" => "https://github.com/JuliaMath/FFTW.jl",
-                     "Distributions" => "https://github.com/JuliaStats/Distributions.jl",
-                     "SpecialFunctions" => "https://github.com/JuliaMath/SpecialFunctions.jl",
-                     "LoopVectorization" => "https://github.com/JuliaSIMD/LoopVectorization.jl",
-                     "Polyester" => "https://github.com/JuliaSIMD/Polyester.jl",
-                     "Tullio" => "https://github.com/mcabbott/Tullio.jl",
-                     "ArrayInterface" => "https://github.com/JuliaArrays/ArrayInterface.jl",
-                     "StaticArrayInterface" => "https://github.com/JuliaArrays/StaticArrayInterface.jl",
-                     "AbstractFFTs" => "https://github.com/JuliaMath/AbstractFFTs.jl",
-                     "GPUArrays" => "https://github.com/JuliaGPU/GPUArrays.jl",
-                     "Tables" => "https://github.com/JuliaData/Tables.jl",
-                     "Unitful" => "https://github.com/PainterQubits/Unitful.jl",
-                     "ReactionMechanismSimulator" => "https://github.com/ReactionMechanismGenerator/ReactionMechanismSimulator.jl",
-                     "FiniteStateProjection" => "https://github.com/kaandocal/FiniteStateProjection.jl",
-                     "AlgebraicPetri" => "https://github.com/AlgebraicJulia/AlgebraicPetri.jl")
+external_urls = Dict(
+    "Enzyme" => "https://github.com/EnzymeAD/Enzyme.jl",
+    "Zygote" => "https://github.com/FluxML/Zygote.jl",
+    "FiniteDiff" => "https://github.com/JuliaDiff/FiniteDiff.jl",
+    "ForwardDiff" => "https://github.com/JuliaDiff/ForwardDiff.jl",
+    "SparseDiffTools" => "https://github.com/JuliaDiff/SparseDiffTools.jl",
+    "ManifoldDiffEq" => "https://github.com/JuliaManifolds/ManifoldDiffEq.jl",
+    "FractionalDiffEq" => "https://github.com/SciFracX/FractionalDiffEq.jl",
+    "Agents" => "https://github.com/JuliaDynamics/Agents.jl",
+    "LowRankIntegrators" => "https://github.com/FHoltorf/LowRankIntegrators.jl",
+    "MomentClosure" => "https://github.com/augustinas1/MomentClosure.jl",
+    "Trixi" => "https://github.com/trixi-framework/Trixi.jl",
+    "Gridap" => "https://github.com/gridap/Gridap.jl",
+    "Ferrite" => "https://github.com/Ferrite-FEM/Ferrite.jl",
+    "ApproxFun" => "https://github.com/JuliaApproximation/ApproxFun.jl",
+    "VoronoiFVM" => "https://github.com/j-fu/VoronoiFVM.jl",
+    "Symbolics" => "https://github.com/JuliaSymbolics/Symbolics.jl",
+    "SymbolicSMT" => "https://github.com/JuliaSymbolics/SymbolicSMT.jl",
+    "SymbolicIntegration" => "https://github.com/JuliaSymbolics/SymbolicIntegration.jl",
+    "SymbolicUtils" => "https://github.com/JuliaSymbolics/SymbolicUtils.jl",
+    "TermInterface" => "https://github.com/JuliaSymbolics/TermInterface.jl",
+    "StaticArrays" => "https://github.com/JuliaArrays/StaticArrays.jl",
+    "FillArrays" => "https://github.com/JuliaArrays/FillArrays.jl",
+    "BandedMatrices" => "https://github.com/JuliaMatrices/BandedMatrices.jl",
+    "BlockBandedMatrices" => "https://github.com/JuliaMatrices/BlockBandedMatrices.jl",
+    "PlotDocs" => "https://github.com/JuliaPlots/PlotDocs.jl",
+    "Makie" => "https://github.com/MakieOrg/Makie.jl",
+    "Measurements" => "https://github.com/JuliaPhysics/Measurements.jl",
+    "MonteCarloMeasurements" => "https://github.com/baggepinnen/MonteCarloMeasurements.jl",
+    "ProbNumDiffEq" => "https://github.com/nathanaelbosch/ProbNumDiffEq.jl",
+    "TaylorIntegration" => "https://github.com/PerezHz/TaylorIntegration.jl",
+    "IntervalArithmetic" => "https://github.com/JuliaIntervals/IntervalArithmetic.jl",
+    "DynamicalSystems" => "https://github.com/JuliaDynamics/DynamicalSystems.jl",
+    "BifurcationKit" => "https://github.com/bifurcationkit/BifurcationKitDocs.jl",
+    "ReachabilityAnalysis" => "https://github.com/JuliaReach/ReachabilityAnalysis.jl",
+    "ControlSystems" => "https://github.com/JuliaControl/ControlSystems.jl",
+    "Flux" => "https://github.com/FluxML/Flux.jl",
+    "Lux" => "https://github.com/LuxDL/Lux.jl",
+    "SimpleChains" => "https://github.com/PumasAI/SimpleChains.jl",
+    "NNlib" => "https://github.com/FluxML/NNlib.jl",
+    "SymbolicRegression" => "https://github.com/MilesCranmer/SymbolicRegression.jl",
+    "FFTW" => "https://github.com/JuliaMath/FFTW.jl",
+    "Distributions" => "https://github.com/JuliaStats/Distributions.jl",
+    "SpecialFunctions" => "https://github.com/JuliaMath/SpecialFunctions.jl",
+    "LoopVectorization" => "https://github.com/JuliaSIMD/LoopVectorization.jl",
+    "Polyester" => "https://github.com/JuliaSIMD/Polyester.jl",
+    "Tullio" => "https://github.com/mcabbott/Tullio.jl",
+    "ArrayInterface" => "https://github.com/JuliaArrays/ArrayInterface.jl",
+    "StaticArrayInterface" => "https://github.com/JuliaArrays/StaticArrayInterface.jl",
+    "AbstractFFTs" => "https://github.com/JuliaMath/AbstractFFTs.jl",
+    "GPUArrays" => "https://github.com/JuliaGPU/GPUArrays.jl",
+    "Tables" => "https://github.com/JuliaData/Tables.jl",
+    "Unitful" => "https://github.com/PainterQubits/Unitful.jl",
+    "ReactionMechanismSimulator" => "https://github.com/ReactionMechanismGenerator/ReactionMechanismSimulator.jl",
+    "FiniteStateProjection" => "https://github.com/kaandocal/FiniteStateProjection.jl",
+    "AlgebraicPetri" => "https://github.com/AlgebraicJulia/AlgebraicPetri.jl"
+)
 
-docs = Any[MultiDocumenter.MultiDocRef(upstream = joinpath(clonedir, "Home"),
-                                       path = "Overview",
-                                       name = "Home",
-                                       giturl = "https://github.com/SciML/SciMLDocs.git")]
+docs = Any[
+    MultiDocumenter.MultiDocRef(
+        upstream = joinpath(clonedir, "Home"),
+        path = "Overview",
+        name = "Home",
+        giturl = "https://github.com/SciML/SciMLDocs.git"
+    ),
+]
 
 for group in docsmodules
     docgroups = []
@@ -195,44 +215,60 @@ for group in docsmodules
             else
                 "https://github.com/SciML/$mod.jl.git"
             end
-            push!(docsites,
-                  MultiDocumenter.MultiDocRef(upstream = joinpath(clonedir, mod),
-                                              path = mod,
-                                              name = mod in keys(fixnames) ? fixnames[mod] :
-                                                     mod,
-                                              giturl = url,
-                                              branch = mod ∈ usemain ? "main" : "gh-pages"))
+            push!(
+                docsites,
+                MultiDocumenter.MultiDocRef(
+                    upstream = joinpath(clonedir, mod),
+                    path = mod,
+                    name = mod in keys(fixnames) ? fixnames[mod] :
+                        mod,
+                    giturl = url,
+                    branch = mod ∈ usemain ? "main" : "gh-pages"
+                )
+            )
         end
         push!(docgroups, MultiDocumenter.Column(cat[1], docsites))
     end
     push!(docs, MultiDocumenter.MegaDropdownNav(group[1], docgroups))
 end
 
-push!(docs, MultiDocumenter.MegaDropdownNav(
-    "Commercial Support",
-    [
-        MultiDocumenter.Column("Commercial Support", [JuliaHubCommercialSupportComponent("https://juliahub.com/company/contact-us-sciml-docs")]),
-        MultiDocumenter.Column("Products built with SciML", [ProductsUsedComponent()]),
-    ]
-))
+push!(
+    docs, MultiDocumenter.MegaDropdownNav(
+        "Commercial Support",
+        [
+            MultiDocumenter.Column("Commercial Support", [JuliaHubCommercialSupportComponent("https://juliahub.com/company/contact-us-sciml-docs")]),
+            MultiDocumenter.Column("Products built with SciML", [ProductsUsedComponent()]),
+        ]
+    )
+)
 
 outpath = joinpath(@__DIR__, "build")
 
-MultiDocumenter.make(outpath, docs;
-                     assets_dir = "docs/src/assets",
-                     search_engine = MultiDocumenter.SearchConfig(index_versions = [
-                                                                      "stable",
-                                                                  ],
-                                                                  engine = MultiDocumenter.FlexSearch),
-                     custom_scripts = [
-                         "https://www.googletagmanager.com/gtag/js?id=G-Q3FE4BYYHQ",
-                         Docs.HTML("""
-                         window.dataLayer = window.dataLayer || [];
-                         function gtag(){dataLayer.push(arguments);}
-                         gtag('js', new Date());
-                         gtag('config', 'G-Q3FE4BYYHQ');
-                         """),
-                     ],
-                     brand_image = MultiDocumenter.BrandImage("https://sciml.ai",
-                                                              joinpath("assets",
-                                                                       "logo.png")))
+MultiDocumenter.make(
+    outpath, docs;
+    assets_dir = "docs/src/assets",
+    search_engine = MultiDocumenter.SearchConfig(
+        index_versions = [
+            "stable",
+        ],
+        engine = MultiDocumenter.FlexSearch
+    ),
+    custom_scripts = [
+        "https://www.googletagmanager.com/gtag/js?id=G-Q3FE4BYYHQ",
+        Docs.HTML(
+            """
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', 'G-Q3FE4BYYHQ');
+            """
+        ),
+    ],
+    brand_image = MultiDocumenter.BrandImage(
+        "https://sciml.ai",
+        joinpath(
+            "assets",
+            "logo.png"
+        )
+    )
+)


### PR DESCRIPTION
## Summary
- Updated CI workflow to use `fredrikekre/runic-action@v1` instead of JuliaFormatter
- Removed `.JuliaFormatter.toml` configuration file
- Reformatted all source files with Runic.jl

## Changes
This PR migrates the code formatting from JuliaFormatter with SciMLStyle to Runic.jl. Runic.jl is an opinionated formatter (similar to Go's gofmt) that requires no configuration.

Key differences from JuliaFormatter:
- Explicit `return` statements are added where implicit
- Different indentation and alignment for continuation lines
- Consistent multiline formatting for function arguments

## Test plan
- [ ] CI format check passes with Runic.jl
- [ ] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)