### PR TITLE
fix: Use Docs.HTML instead of Documenter.HTML for inline scripts

### DIFF
--- a/docs/make_aggregate.jl
+++ b/docs/make_aggregate.jl
@@ -1,4 +1,4 @@
-using Documenter: Documenter, HTML
+using Documenter: Documenter
 using LibGit2
 using Pkg
 using MultiDocumenter
@@ -256,7 +256,7 @@ MultiDocumenter.make(
     ),
     custom_scripts = [
         "https://www.googletagmanager.com/gtag/js?id=G-Q3FE4BYYHQ",
-        HTML(
+        Docs.HTML(
             """
             window.dataLayer = window.dataLayer || [];
             function gtag(){dataLayer.push(arguments);}


### PR DESCRIPTION
## Summary
- Fix build error: `MethodError: no method matching HTML(::String)`

## Problem
The code was importing `HTML` from `Documenter`:
```julia
using Documenter: Documenter, HTML
```

But `Documenter.HTML` is the format specification type (for configuring HTML output options like `prettyurls`, `assets`, etc.), not for embedding inline HTML content.

## Solution
MultiDocumenter's `custom_scripts` parameter expects `Docs.HTML` from Julia's standard library for inline script content. Changed:
- Removed unused `HTML` import from Documenter
- Changed `HTML(...)` to `Docs.HTML(...)` for the inline Google Analytics script

## Test plan
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)