### PR TITLE
Add missing packages and fix NDInterpolations naming

### DIFF
--- a/docs/make_aggregate.jl
+++ b/docs/make_aggregate.jl
@@ -54,6 +54,7 @@ docsmodules = [
             "MethodOfLines", "NeuralPDE",
             "NeuralOperators", "FEniCS",
             "HighDimPDE", "DiffEqOperators",
+            "FiniteVolumeMethod", "FiniteVolumeMethod1D",
         ],
         #=
         "Third-Party PDE Solvers" => [
@@ -81,7 +82,7 @@ docsmodules = [
     ],
     "Machine Learning" => [
         "Function Approximation" => ["Surrogates", "ReservoirComputing"],
-        "Implicit Layer Deep Learning" => ["DiffEqFlux", "DeepEquilibriumNetworks"],
+        "Implicit Layer Deep Learning" => ["DiffEqFlux", "DeepEquilibriumNetworks", "NeuralLyapunov"],
         #= "Third-Party Implicit Layer Deep Learning" => ["Flux", "Lux", "SimpleChains"], =#
         "Symbolic Learning" => ["DataDrivenDiffEq", "SymbolicNumericIntegration"],
         #= "Third-Party Symbolic Learning" => ["SymbolicRegression"], =#
@@ -94,7 +95,7 @@ docsmodules = [
     "Developer Tools" => [
         "Numerical Utilities" => [
             "ExponentialUtilities", "DiffEqNoiseProcess",
-            "PreallocationTools", "EllipsisNotation", "DataInterpolations", "NDInterpolations",
+            "PreallocationTools", "EllipsisNotation", "DataInterpolations", "DataInterpolationsND",
             "PoissonRandom", "QuasiMonteCarlo", "RuntimeGeneratedFunctions", "MuladdMacro", "FindFirstFunctions",
             "SparseDiffTools", "BipartiteGraphs",
         ],


### PR DESCRIPTION
## Summary
- Fix `NDInterpolations` -> `DataInterpolationsND` (correct repo name)
- Add `NeuralLyapunov.jl` to Implicit Layer Deep Learning section
- Add `FiniteVolumeMethod.jl` and `FiniteVolumeMethod1D.jl` to PDE Solvers section

## Test plan
- [ ] Verify documentation builds successfully with the new packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)