### PR TITLE
docs: remove dead Evolutionary.jl docs link failing linkcheck on main

### DIFF
--- a/docs/src/highlevels/equation_solvers.md
+++ b/docs/src/highlevels/equation_solvers.md
@@ -95,7 +95,6 @@ covers:
 
   - OptimizationBBO for [BlackBoxOptim.jl](https://github.com/robertfeldt/BlackBoxOptim.jl)
   - OptimizationEvolutionary for [Evolutionary.jl](https://github.com/wildart/Evolutionary.jl)
-    (see also [this documentation](https://wildart.github.io/Evolutionary.jl/dev/))
   - OptimizationGCMAES for [GCMAES.jl](https://github.com/AStupidBear/GCMAES.jl)
   - OptimizationMOI for [MathOptInterface.jl](https://github.com/jump-dev/MathOptInterface.jl)
     (usage of algorithm via MathOptInterface API; see also the API


### PR DESCRIPTION
## Summary

The `Documentation` workflow on `main` ("Build Documentation" job) is failing because the Documenter `linkcheck` finds a dead link and terminates the build with `makedocs encountered errors [:linkcheck, :example_block]`.

This PR fixes the deterministic `:linkcheck` cause: the "see also this documentation" link in `docs/src/highlevels/equation_solvers.md` pointing to

```
https://wildart.github.io/Evolutionary.jl/dev/
```

That GitHub Pages site is gone — `/dev/`, `/stable/`, and the root all return `404` (the project's docs hosting has lapsed, even though its README badges still reference it). The `Evolutionary.jl` GitHub repository link on the same line is still live (301 → SciML/Evolutionary.jl), so only the broken docs parenthetical is dropped.

This same 404 was failing the docs build on both the 2026-06-03 and 2026-06-07 pushes to `main`.

## Scope / what this does NOT fix

The failing `main` build had three checks red; this PR addresses only the deterministic, in-repo cause:

- **Build Documentation** — also reported `:example_block` failures, but those are all `Out of GPU memory` / CUDA `throw_api_error` on the self-hosted GPU runner (the cascading `UndefVarError`s are downstream of the GPU OOM). On 2026-06-03 those same example blocks ran fine, so the GPU OOM is intermittent runner-resource exhaustion, not a code regression. Not fixable in-repo without disabling examples.
- **Build and Deploy Aggregate Documentation** — failed at the "Install AWS CLI" step (`Found preexisting AWS CLI installation … rerun install script with --update flag`); on 2026-06-03 the analogous failure was a transient `aws s3 sync` exit 2. Both are self-hosted-runner provisioning/transient issues, not in-repo doc problems.
- **runic / Runic Format Check** — died at the `actions/checkout` step (`could not read Username for 'https://github.com'` → operation canceled). Transient runner/credential flake in the centralized `runic.yml@v1` caller; Runic never ran, so there is no real formatting violation.

## Local verification

Built an isolated Documenter site over just the edited page with `linkcheck = true`:

- Before (original content): `Error: linkcheck 'https://wildart.github.io/Evolutionary.jl/dev/' status: 404.` → `makedocs encountered an error [:linkcheck]` (reproduces the CI failure).
- After (this change): build completes, exit 0 (`LINKCHECK_BUILD_OK`); the only remaining linkcheck messages are benign `301` redirect Warnings.

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
