### PR TITLE
Ignore NLopt readthedocs link in linkcheck (transient HTTP 429)

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -41,6 +41,8 @@ makedocs(
         "http://www.scholarpedia.org/article/Differential-algebraic_equations",
         "https://computing.llnl.gov/projects/sundials",
         "https://github.com/timholy/QuadDIRECT.jl",
+        # readthedocs.io rate-limits CI runners and returns HTTP 429
+        "https://nlopt.readthedocs.io/en/latest/NLopt_Algorithms/",
     ],
     format = HTML(
         assets = ["assets/favicon.ico"],


### PR DESCRIPTION
The **Build Documentation** job on `main` is red because Documenter`s `linkcheck` hits `https://nlopt.readthedocs.io/en/latest/NLopt_Algorithms/` and receives **HTTP 429 (Too Many Requests)**. `readthedocs.io` rate-limits the self-hosted CI runner IP; the page itself is live (returns `200` from a normal request, verified via `curl`). Any error-status link terminates `makedocs` before rendering:

```
┌ Error: linkcheck 'https://nlopt.readthedocs.io/en/latest/NLopt_Algorithms/' status: 429.
ERROR: LoadError: `makedocs` encountered an error [:linkcheck] -- terminating build before rendering.
```

## Fix

Add the URL to `linkcheck_ignore` in `docs/make.jl`, consistent with the ~12 other intermittently-blocked URLs already listed there (SIAM epubs, biorxiv, scholarpedia, LLNL Sundials, etc.). Every other link remains checked.

## Local verification (Julia 1.11, the version CI uses)

Reproduced the exact failure mechanism with a minimal Documenter build:
- `linkcheck=true` with an error-status link → `Error: linkcheck ... status: <code>` and `makedocs encountered an error [:linkcheck] -- terminating build before rendering` (identical failure class to CI).
- Same URL placed in `linkcheck_ignore` → build succeeds, URL is skipped.

`make.jl` parses cleanly and Runic reports it already correctly formatted.

## Note on the second red check

The **Build and Deploy Aggregate Documentation** job is also red, but for an unrelated, transient reason: the MultiDocumenter build succeeded and `aws s3 sync` uploaded all 33.5 GiB / ~227k files, then exited with code `2` (AWS CLI`s "one or more transfers failed/retried" code) with no error output. That is a self-hosted-runner / S3 infra flake on the deploy step, not an in-repo code issue, and is not addressed here.

---

Please ignore until reviewed by @ChrisRackauckas