### PR TITLE
docs CI: restore scheduled S3 deploy and prune broken symlinks

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -1,10 +1,10 @@
 name: "Documentation"
 
 on:
-  # Daily rebuild so downstream package gh-pages updates propagate to docs.sciml.ai
+  # Rebuild every 6 hours so downstream package gh-pages updates propagate to docs.sciml.ai
   # (restores the scheduled deploy that Buildkite ran before the 2026-03 GHA migration).
   schedule:
-    - cron: '0 6 * * *'
+    - cron: '0 */6 * * *'
   workflow_dispatch:
   pull_request:
     branches:

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -1,6 +1,11 @@
 name: "Documentation"
 
 on:
+  # Daily rebuild so downstream package gh-pages updates propagate to docs.sciml.ai
+  # (restores the scheduled deploy that Buildkite ran before the 2026-03 GHA migration).
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
   pull_request:
     branches:
       - main
@@ -61,8 +66,13 @@ jobs:
           julia --project=docs/ docs/make_aggregate.jl
         env:
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
+      - name: "Prune broken symlinks"
+        if: github.event_name != 'pull_request'
+        # Dangling version-alias symlinks (e.g. a package's vX.Y -> missing patch dir) make
+        # `aws s3 sync` skip them and exit 2, which fails the whole deploy.
+        run: find docs/build -xtype l -print -delete
       - name: "Install AWS CLI"
-        if: github.event_name == 'push'
+        if: github.event_name != 'pull_request'
         run: |
           if ! command -v aws &> /dev/null && [ ! -x "$HOME/aws-cli/bin/aws" ]; then
             curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
@@ -73,7 +83,7 @@ jobs:
           export PATH="$HOME/bin:$PATH"
           aws --version
       - name: "Deploy to S3"
-        if: github.event_name == 'push'
+        if: github.event_name != 'pull_request'
         run: |
           export PATH="$HOME/bin:$PATH"
           aws s3 sync --delete --acl=public-read docs/build s3://docs.sciml.ai --cache-control max-age=600


### PR DESCRIPTION
## Problem

`docs.sciml.ai` (the aggregate site, served from S3) has been stuck — e.g. **DiffEqDocs v8.0.0** built and deployed to its own `gh-pages` on 2026-06-24, but the public site still shows v7. Root causes:

1. **No periodic deploy.** Before the 2026-03 migration from Buildkite to GitHub Actions (commit `8445d505a`), Buildkite ran a **scheduled build** (configured in the Buildkite web UI) that rebuilt the aggregate from every package's current `gh-pages` and `aws s3 sync`'d it to S3. The old `.buildkite/documentation.yml` even guarded with `build.source != "schedule"`, confirming scheduled builds were routine. That schedule had no committed file to translate, so the GHA `Documentation.yml` was written with only `push`/`pull_request` to `main`. Result: the site only refreshes when someone happens to push to `main`, so downstream package doc updates never propagate on their own.

2. **Deploy gated to `push` only.** Even with a schedule added, the `Install AWS CLI` and `Deploy to S3` steps were `if: github.event_name == 'push'`, so scheduled/manual runs would build but skip the deploy.

3. **`aws s3 sync` exit 2.** The deploy step has been red on every push run since at least 2026-05-10 because a dangling version-alias symlink (e.g. `docs/build/SymbolicSMT/v1.0` pointing at a missing patch dir) makes `aws s3 sync` skip it and exit 2, failing the step.

## Fix

- Add `schedule` (every 6 hours `0 */6 * * *`) and `workflow_dispatch` triggers — restores the pre-migration scheduled deploy and adds a manual "deploy now" button.
- Broaden the `Install AWS CLI` / `Deploy to S3` gate from `github.event_name == 'push'` to `github.event_name != 'pull_request'`, so scheduled and manual runs deploy while PR previews still don't.
- Add a `Prune broken symlinks` step (`find docs/build -xtype l -print -delete`) before the sync, so dangling symlinks no longer fail the deploy. Only broken links are removed; valid version-alias symlinks resolve and are untouched.

## Verification

YAML validated with `python3` (`yaml.safe_load`): triggers resolve to `schedule, workflow_dispatch, pull_request, push`; all three deploy-related steps now carry `if: github.event_name != 'pull_request'`. Full build+deploy can only be verified on the self-hosted runner via a push/dispatch to `main`.

This does **not** disable any check or set `warnonly`.

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)