### PR TITLE
Use the canonical OpenReview forum URL

### DIFF
--- a/docs/src/comparisons/cppfortran.md
+++ b/docs/src/comparisons/cppfortran.md
@@ -120,7 +120,7 @@ highlight include:
     have high-level context-dependent mathematical knowledge. Julia's SciML makes
     [extensive use of customized symbolic-based compiler transformations](https://twitter.com/ChrisRackauckas/status/1477274812460449793)
     to improve performance with context-based code optimizations. Things like
-    [sparsity patterns are automatically deduced from code and optimized on](https://openreview.net/pdf?id=rJlPdcY38B). [Nonlinear equations are symbolically-torn](https://www.youtube.com/watch?v=ZFoQihr3xLs), changing large nonlinear systems into sequential solving of much smaller
+    [sparsity patterns are automatically deduced from code and optimized on](https://openreview.net/forum?id=rJlPdcY38B). [Nonlinear equations are symbolically-torn](https://www.youtube.com/watch?v=ZFoQihr3xLs), changing large nonlinear systems into sequential solving of much smaller
     systems and benefiting from an O(n^3) cost reduction. These can be orders of magnitude
     cost reductions which come for free, and unless you know every trick in the book it will
     be difficult to match SciML's performance!


### PR DESCRIPTION
Please ignore this draft until it has been reviewed by @ChrisRackauckas.

## What changed and why

The C++/Fortran comparison now links to the canonical OpenReview forum page instead of the PDF endpoint. The PDF endpoint returns HTTP 403 to Documenter's link checker; the forum endpoint allows the docs build to render while retaining link checking.

## Verification

Both fixtures used this exact command; only the URL in `linkcheck_probe/src/index.md` changed:

```bash
~/.juliaup/bin/julia +1.11 --project=/home/crackauc/sandbox/tmp_20260825_200154_10547/scimldocs_base_failures/docs --startup-file=no -e '
using Documenter
makedocs(
    root = "/home/crackauc/sandbox/tmp_20260825_200154_10547/linkcheck_probe",
    source = "src",
    build = "build",
    clean = true,
    sitename = "Linkcheck probe",
    modules = Module[],
    remotes = nothing,
    linkcheck = true,
    pages = ["index.md"],
)
'
```

The original URL failed:

```text
https://openreview.net/pdf?id=rJlPdcY38B
HTTP 403
exit code 1
```

The replacement URL returned OpenReview's challenge redirect as a warning and rendered successfully:

```text
https://openreview.net/forum?id=rJlPdcY38B
HTTP 307
exit code 0
```

Runic, `typos`, and `git diff --check` completed with exit code 0 on the changed file. Link checking remains enabled.

## Not verified

The full standard docs build remains red on unchanged GPU pages because this host has no NVIDIA driver. The official workflow runs those pages on a self-hosted GPU runner.

🤖 Generated with OpenAI Codex
