### PR TITLE
Give every SciML package a place in SciMLDocs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,11 +6,13 @@ version = "1.7.0"
 [deps]
 
 [compat]
+TOML = "1"
 julia = "1.10"
 
 [extras]
 ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ExplicitImports", "Test"]
+test = ["ExplicitImports", "TOML", "Test"]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -116,6 +116,7 @@ makedocs(
                 "highlevels/developer_documentation.md",
             ],
             "Extra Learning Resources" => ["highlevels/learning_resources.md"],
+            "Package Index" => "highlevels/package_index.md",
         ],
     ],
 )

--- a/docs/make_aggregate.jl
+++ b/docs/make_aggregate.jl
@@ -13,6 +13,8 @@ docsmodules = [
         "Modeling Languages" => [
             "ModelingToolkit", "Catalyst", "NBodySimulator",
             "ParameterizedFunctions",
+            "Corleone", "ProcessSimulator", "MomentClosure",
+            "DiffEqFinancial",
         ],
         "Model Libraries and Importers" => [
             "ModelingToolkitStandardLibrary",
@@ -22,10 +24,15 @@ docsmodules = [
             "CellMLToolkit", "SBMLToolkit",
             "BaseModelica",
             "ReactionNetworkImporters",
+            "DiffEqPhysics", "PubChem", "Pyomo", "MathML",
         ],
-        "Symbolic Tools" => ["ModelOrderReduction", "Symbolics", "SymbolicUtils", "SymbolicIntegration", "SymbolicSMT", "SymbolicLimits", "SymbolicAnalysis"], #="MetaTheory"=#
+        "Symbolic Tools" => [
+            "ModelOrderReduction", "Symbolics", "SymbolicUtils",
+            "SymbolicIntegration", "SymbolicSMT", "SymbolicLimits",
+            "SymbolicAnalysis", "FunctionProperties",
+        ], #="MetaTheory"=#
         #=
-        "Third-Party Modeling Tools" => ["MomentClosure", "Agents", "Unitful",
+        "Third-Party Modeling Tools" => ["Agents", "Unitful",
             "ReactionMechanismSimulator",
             "AlgebraicPetri"],
         =#
@@ -39,6 +46,7 @@ docsmodules = [
         "Equation Solvers" => [
             "LinearSolve", "NonlinearSolve", "DiffEqDocs", "Integrals",
             "DifferenceEquations", "Optimization", "JumpProcesses", "LineSearch",
+            "Evolutionary", "NeuralLinearSolve",
         ],
         #=
         "Third-Party Equation Solvers" => [
@@ -65,14 +73,23 @@ docsmodules = [
             "VoronoiFVM",
         ],
         =#
-        "Advanced Solver APIs" => ["OrdinaryDiffEq", "BoundaryValueDiffEq", "DiffEqGPU"],
+        "Advanced Solver APIs" => [
+            "OrdinaryDiffEq", "BoundaryValueDiffEq", "DiffEqGPU",
+            "SteadyStateDiffEq", "OrdinaryDiffEqOperatorSplitting",
+            "IRKGaussLegendre", "MATLABDiffEq", "QuantumNLDiffEq",
+        ],
     ],
     "Analysis" => [
         #= "Plots and Visualization" => ["Makie"], #="PlotDocs",=# =#
-        "Parameter Analysis" => ["EasyModelAnalysis", "GlobalSensitivity", "StructuralIdentifiability"],
+        "Parameter Analysis" => [
+            "EasyModelAnalysis", "GlobalSensitivity", "StructuralIdentifiability",
+            "MinimallyDisruptiveCurves", "CatalystNetworkAnalysis",
+        ],
         "Third-Party Parameter Analysis" => ["BifurcationKit"],
         #= "DynamicalSystems", "ControlSystems", "ReachabilityAnalysis"], =#
-        "Uncertainty Quantification" => ["PolyChaos", "SciMLExpectations"],
+        "Uncertainty Quantification" => [
+            "PolyChaos", "SciMLExpectations", "OptimalUncertaintyQuantification",
+        ],
         #=
         "Third-Party Uncertainty Quantification" => ["Measurements",
             "MonteCarloMeasurements",
@@ -98,6 +115,11 @@ docsmodules = [
             "PreallocationTools", "EllipsisNotation", "DataInterpolations", "DataInterpolationsND",
             "PoissonRandom", "QuasiMonteCarlo", "RuntimeGeneratedFunctions", "MuladdMacro", "FindFirstFunctions",
             "SparseDiffTools", "BipartiteGraphs",
+            "FastAlmostBandedMatrices", "FastBroadcast", "FunctionWrappersWrappers",
+            "LHLFactorization", "LightweightStats",
+            "PureGebal", "PureKLU", "PureUMFPACK",
+            "RootedTrees", "SparseBandedMatrices", "RespecializeParams",
+            "ConcreteStructs",
         ],
         #=
         "Third-Party Numerical Utilities" => ["FFTW", "Distributions",
@@ -114,11 +136,15 @@ docsmodules = [
             "SciMLOperators",
             "SurrogatesBase",
             "CommonSolve",
+            "SciMLIterators",
+            "Static",
         ],
         "Third-Party Interfaces" => ["ArrayInterface", "StaticArrayInterface" #= "AbstractFFTs",
             "GPUArrays", #= "Adapt", =#
             "Tables" =#],                                 #= "RecipesBase", =#
-        "Developer Documentation" => ["SciMLStyle", "ColPrac", "DiffEqDevDocs"],
+        "Developer Documentation" => [
+            "SciMLStyle", "ColPrac", "DiffEqDevDocs", "OrgMaintenanceScripts",
+        ],
         "Extra Resources" => [
             "SciMLWorkshop",
             "SciMLTutorialsOutput",
@@ -149,7 +175,6 @@ external_urls = Dict(
     "FractionalDiffEq" => "https://github.com/SciFracX/FractionalDiffEq.jl",
     "Agents" => "https://github.com/JuliaDynamics/Agents.jl",
     "LowRankIntegrators" => "https://github.com/FHoltorf/LowRankIntegrators.jl",
-    "MomentClosure" => "https://github.com/augustinas1/MomentClosure.jl",
     "Trixi" => "https://github.com/trixi-framework/Trixi.jl",
     "Gridap" => "https://github.com/gridap/Gridap.jl",
     "Ferrite" => "https://github.com/Ferrite-FEM/Ferrite.jl",
@@ -192,7 +217,6 @@ external_urls = Dict(
     "Tables" => "https://github.com/JuliaData/Tables.jl",
     "Unitful" => "https://github.com/PainterQubits/Unitful.jl",
     "ReactionMechanismSimulator" => "https://github.com/ReactionMechanismGenerator/ReactionMechanismSimulator.jl",
-    "FiniteStateProjection" => "https://github.com/kaandocal/FiniteStateProjection.jl",
     "AlgebraicPetri" => "https://github.com/AlgebraicJulia/AlgebraicPetri.jl"
 )
 

--- a/docs/make_aggregate.jl
+++ b/docs/make_aggregate.jl
@@ -13,8 +13,7 @@ docsmodules = [
         "Modeling Languages" => [
             "ModelingToolkit", "Catalyst", "NBodySimulator",
             "ParameterizedFunctions",
-            "Corleone", "ProcessSimulator", "MomentClosure",
-            "DiffEqFinancial",
+            "ProcessSimulator", "MomentClosure",
         ],
         "Model Libraries and Importers" => [
             "ModelingToolkitStandardLibrary",
@@ -24,7 +23,8 @@ docsmodules = [
             "CellMLToolkit", "SBMLToolkit",
             "BaseModelica",
             "ReactionNetworkImporters",
-            "DiffEqPhysics", "PubChem", "Pyomo", "MathML",
+            "DiffEqPhysics", "DiffEqFinancial",
+            "PubChem", "Pyomo", "MathML",
         ],
         "Symbolic Tools" => [
             "ModelOrderReduction", "Symbolics", "SymbolicUtils",
@@ -46,7 +46,7 @@ docsmodules = [
         "Equation Solvers" => [
             "LinearSolve", "NonlinearSolve", "DiffEqDocs", "Integrals",
             "DifferenceEquations", "Optimization", "JumpProcesses", "LineSearch",
-            "Evolutionary", "NeuralLinearSolve",
+            "Evolutionary", "NeuralLinearSolve", "Corleone",
         ],
         #=
         "Third-Party Equation Solvers" => [

--- a/docs/package_inventory.toml
+++ b/docs/package_inventory.toml
@@ -1,0 +1,988 @@
+# Complete inventory of SciML repositories tracked by SciMLDocs.
+# placement = dropdown | embedded | overview | extra | infra
+# Tested by test/package_coverage.jl.
+
+[packages."BoundaryValueDiffEq.jl"]
+placement = "dropdown"
+category = "Advanced Solver APIs"
+blurb = "Boundary-value problem solvers."
+dropdown = "BoundaryValueDiffEq"
+
+[packages."DiffEqGPU.jl"]
+placement = "dropdown"
+category = "Advanced Solver APIs"
+blurb = "GPU ensemble acceleration for DiffEq."
+dropdown = "DiffEqGPU"
+
+[packages."IRKGaussLegendre.jl"]
+placement = "dropdown"
+category = "Advanced Solver APIs"
+blurb = "16th-order implicit RK Gauss–Legendre."
+dropdown = "IRKGaussLegendre"
+
+[packages."MATLABDiffEq.jl"]
+placement = "dropdown"
+category = "Advanced Solver APIs"
+blurb = "MATLAB ODE solver wrappers on the SciML interface."
+dropdown = "MATLABDiffEq"
+
+[packages."OrdinaryDiffEq.jl"]
+placement = "dropdown"
+category = "Advanced Solver APIs"
+blurb = "High-performance ODE/DAE solvers; API also embedded in DiffEqDocs."
+dropdown = "OrdinaryDiffEq"
+
+[packages."OrdinaryDiffEqOperatorSplitting.jl"]
+placement = "dropdown"
+category = "Advanced Solver APIs"
+blurb = "Operator-splitting solvers for split ODE/DAE formulations."
+dropdown = "OrdinaryDiffEqOperatorSplitting"
+
+[packages."QuantumNLDiffEq.jl"]
+placement = "dropdown"
+category = "Advanced Solver APIs"
+blurb = "Differential quantum circuits for nonlinear DEs."
+dropdown = "QuantumNLDiffEq"
+
+[packages."SteadyStateDiffEq.jl"]
+placement = "dropdown"
+category = "Advanced Solver APIs"
+blurb = "Steady-state solvers for DiffEq; API also in DiffEqDocs."
+dropdown = "SteadyStateDiffEq"
+
+[packages."ComponentArrays.jl"]
+placement = "dropdown"
+category = "Array Libraries"
+blurb = "Arrays with arbitrarily nested named components."
+dropdown = "ComponentArrays"
+
+[packages."LabelledArrays.jl"]
+placement = "dropdown"
+category = "Array Libraries"
+blurb = "Named elements on arrays without overhead."
+dropdown = "LabelledArrays"
+
+[packages."MultiScaleArrays.jl"]
+placement = "dropdown"
+category = "Array Libraries"
+blurb = "Multiscale array types that compose with equation solvers."
+dropdown = "MultiScaleArrays"
+
+[packages."RecursiveArrayTools.jl"]
+placement = "dropdown"
+category = "Array Libraries"
+blurb = "Nested arrays compatible with SciML solvers."
+dropdown = "RecursiveArrayTools"
+
+[packages."ColPrac"]
+placement = "dropdown"
+category = "Developer Documentation"
+blurb = "Collaborative practices for community packages."
+dropdown = "ColPrac"
+
+[packages."DiffEqDevDocs.jl"]
+placement = "dropdown"
+category = "Developer Documentation"
+blurb = "DiffEq developer documentation (archived repo, still published)."
+dropdown = "DiffEqDevDocs"
+
+[packages."OrgMaintenanceScripts.jl"]
+placement = "dropdown"
+category = "Developer Documentation"
+blurb = "Scripts for maintaining a large GitHub organization."
+dropdown = "OrgMaintenanceScripts"
+
+[packages."SciMLStyle"]
+placement = "dropdown"
+category = "Developer Documentation"
+blurb = "SciML Julia style guide."
+dropdown = "SciMLStyle"
+
+[packages."DiffEqDocs.jl"]
+placement = "dropdown"
+category = "Equation Solvers"
+blurb = "DifferentialEquations.jl documentation (umbrella for the DiffEq solvers)."
+dropdown = "DiffEqDocs"
+
+[packages."DifferenceEquations.jl"]
+placement = "dropdown"
+category = "Equation Solvers"
+blurb = "Deterministic and stochastic difference equations and state-space likelihoods."
+dropdown = "DifferenceEquations"
+
+[packages."Evolutionary.jl"]
+placement = "dropdown"
+category = "Equation Solvers"
+blurb = "Evolutionary and genetic algorithms."
+dropdown = "Evolutionary"
+
+[packages."Integrals.jl"]
+placement = "dropdown"
+category = "Equation Solvers"
+blurb = "Unified interface for quadrature."
+dropdown = "Integrals"
+
+[packages."JumpProcesses.jl"]
+placement = "dropdown"
+category = "Equation Solvers"
+blurb = "Jump processes, Gillespie SSAs, and jump-diffusions."
+dropdown = "JumpProcesses"
+
+[packages."LinearSolve.jl"]
+placement = "dropdown"
+category = "Equation Solvers"
+blurb = "Unified interface for linear solvers."
+dropdown = "LinearSolve"
+
+[packages."LineSearch.jl"]
+placement = "dropdown"
+category = "Equation Solvers"
+blurb = "Unified line-search interface."
+dropdown = "LineSearch"
+
+[packages."NeuralLinearSolve.jl"]
+placement = "dropdown"
+category = "Equation Solvers"
+blurb = "CNN that picks UMFPACK/KLU/Pardiso for a sparse matrix."
+dropdown = "NeuralLinearSolve"
+
+[packages."NonlinearSolve.jl"]
+placement = "dropdown"
+category = "Equation Solvers"
+blurb = "Unified interface for nonlinear solvers and bracketing."
+dropdown = "NonlinearSolve"
+
+[packages."Optimization.jl"]
+placement = "dropdown"
+category = "Equation Solvers"
+blurb = "Unified interface for mathematical optimization."
+dropdown = "Optimization"
+
+[packages."ModelingToolkitCourse"]
+placement = "dropdown"
+category = "Extra Resources"
+blurb = "ModelingToolkit course notes."
+dropdown = "ModelingToolkitCourse"
+
+[packages."SciMLBenchmarksOutput"]
+placement = "dropdown"
+category = "Extra Resources"
+blurb = "Rendered SciML benchmarks site."
+dropdown = "SciMLBenchmarksOutput"
+
+[packages."SciMLTutorialsOutput"]
+placement = "dropdown"
+category = "Extra Resources"
+blurb = "Rendered extended tutorials (archived repo, still published)."
+dropdown = "SciMLTutorialsOutput"
+
+[packages."SciMLWorkshop.jl"]
+placement = "dropdown"
+category = "Extra Resources"
+blurb = "Workshop materials for SciML training."
+dropdown = "SciMLWorkshop"
+
+[packages."ReservoirComputing.jl"]
+placement = "dropdown"
+category = "Function Approximation"
+blurb = "Reservoir computing."
+dropdown = "ReservoirComputing"
+
+[packages."Surrogates.jl"]
+placement = "dropdown"
+category = "Function Approximation"
+blurb = "Surrogate modeling and optimization."
+dropdown = "Surrogates"
+
+[packages."ADTypes.jl"]
+placement = "dropdown"
+category = "High-Level Interfaces"
+blurb = "Automatic-differentiation backend types."
+dropdown = "ADTypes"
+
+[packages."CommonSolve.jl"]
+placement = "dropdown"
+category = "High-Level Interfaces"
+blurb = "Shared `solve` / `init` / `solve!` definition."
+dropdown = "CommonSolve"
+
+[packages."SciMLBase.jl"]
+placement = "dropdown"
+category = "High-Level Interfaces"
+blurb = "Core SciML problem/algorithm/solution interfaces."
+dropdown = "SciMLBase"
+
+[packages."SciMLIterators.jl"]
+placement = "dropdown"
+category = "High-Level Interfaces"
+blurb = "Iterators over SciML solutions and integrators."
+dropdown = "SciMLIterators"
+
+[packages."SciMLLogging.jl"]
+placement = "dropdown"
+category = "High-Level Interfaces"
+blurb = "Verbosity and logging for SciML solvers."
+dropdown = "SciMLLogging"
+
+[packages."SciMLOperators.jl"]
+placement = "dropdown"
+category = "High-Level Interfaces"
+blurb = "Matrix-free linear and affine operators."
+dropdown = "SciMLOperators"
+
+[packages."SciMLStructures.jl"]
+placement = "dropdown"
+category = "High-Level Interfaces"
+blurb = "Queryable structure interface for user data and parameters."
+dropdown = "SciMLStructures"
+
+[packages."Static.jl"]
+placement = "dropdown"
+category = "High-Level Interfaces"
+blurb = "Statically parameterized types for compile-time computation."
+dropdown = "Static"
+
+[packages."SurrogatesBase.jl"]
+placement = "dropdown"
+category = "High-Level Interfaces"
+blurb = "API for deterministic and stochastic surrogates."
+dropdown = "SurrogatesBase"
+
+[packages."SymbolicIndexingInterface.jl"]
+placement = "dropdown"
+category = "High-Level Interfaces"
+blurb = "Symbolic indexing of SciML objects."
+dropdown = "SymbolicIndexingInterface"
+
+[packages."DeepEquilibriumNetworks.jl"]
+placement = "dropdown"
+category = "Implicit Layer Deep Learning"
+blurb = "Deep equilibrium networks."
+dropdown = "DeepEquilibriumNetworks"
+
+[packages."DiffEqFlux.jl"]
+placement = "dropdown"
+category = "Implicit Layer Deep Learning"
+blurb = "Prebuilt implicit deep-learning architectures (Neural ODEs, …)."
+dropdown = "DiffEqFlux"
+
+[packages."NeuralLyapunov.jl"]
+placement = "dropdown"
+category = "Implicit Layer Deep Learning"
+blurb = "Search for neural Lyapunov functions."
+dropdown = "NeuralLyapunov"
+
+[packages."CurveFit.jl"]
+placement = "dropdown"
+category = "Inverse Problems / Estimation"
+blurb = "Least-squares and curve fitting on the CommonSolve interface."
+dropdown = "CurveFit"
+
+[packages."DiffEqBayes.jl"]
+placement = "dropdown"
+category = "Inverse Problems / Estimation"
+blurb = "Simplified Bayesian estimation of DiffEq parameters."
+dropdown = "DiffEqBayes"
+
+[packages."DiffEqParamEstim.jl"]
+placement = "dropdown"
+category = "Inverse Problems / Estimation"
+blurb = "Simplified parameter-estimation loss functions."
+dropdown = "DiffEqParamEstim"
+
+[packages."SciMLSensitivity.jl"]
+placement = "dropdown"
+category = "Inverse Problems / Estimation"
+blurb = "Local sensitivity, adjoints, and AD of solvers."
+dropdown = "SciMLSensitivity"
+
+[packages."BaseModelica.jl"]
+placement = "dropdown"
+category = "Model Libraries and Importers"
+blurb = "Base Modelica importer for ModelingToolkit."
+dropdown = "BaseModelica"
+
+[packages."CellMLToolkit.jl"]
+placement = "dropdown"
+category = "Model Libraries and Importers"
+blurb = "CellML importer for ModelingToolkit."
+dropdown = "CellMLToolkit"
+
+[packages."DiffEqCallbacks.jl"]
+placement = "dropdown"
+category = "Model Libraries and Importers"
+blurb = "Premade callbacks for hybrid differential-equation models."
+dropdown = "DiffEqCallbacks"
+
+[packages."DiffEqPhysics.jl"]
+placement = "dropdown"
+category = "Model Libraries and Importers"
+blurb = "Hamiltonian and physics-based DiffEq problem constructors."
+dropdown = "DiffEqPhysics"
+
+[packages."FiniteStateProjection.jl"]
+placement = "dropdown"
+category = "Model Libraries and Importers"
+blurb = "Finite-state projection of chemical master equations."
+dropdown = "FiniteStateProjection"
+
+[packages."MathML.jl"]
+placement = "dropdown"
+category = "Model Libraries and Importers"
+blurb = "MathML parser into Symbolics expressions."
+dropdown = "MathML"
+
+[packages."ModelingToolkitNeuralNets.jl"]
+placement = "dropdown"
+category = "Model Libraries and Importers"
+blurb = "Neural-network blocks for universal differential equations in MTK."
+dropdown = "ModelingToolkitNeuralNets"
+
+[packages."ModelingToolkitStandardLibrary.jl"]
+placement = "dropdown"
+category = "Model Libraries and Importers"
+blurb = "Standard component library for ModelingToolkit."
+dropdown = "ModelingToolkitStandardLibrary"
+
+[packages."PubChem.jl"]
+placement = "dropdown"
+category = "Model Libraries and Importers"
+blurb = "PubChem metadata attached to Catalyst species."
+dropdown = "PubChem"
+
+[packages."Pyomo.jl"]
+placement = "dropdown"
+category = "Model Libraries and Importers"
+blurb = "Pyomo interface via Symbolics.jl."
+dropdown = "Pyomo"
+
+[packages."ReactionNetworkImporters.jl"]
+placement = "dropdown"
+category = "Model Libraries and Importers"
+blurb = "BioNetGen and stoichiometry-matrix importers."
+dropdown = "ReactionNetworkImporters"
+
+[packages."SBMLToolkit.jl"]
+placement = "dropdown"
+category = "Model Libraries and Importers"
+blurb = "SBML importer for Catalyst and ModelingToolkit."
+dropdown = "SBMLToolkit"
+
+[packages."Catalyst.jl"]
+placement = "dropdown"
+category = "Modeling Languages"
+blurb = "Chemical reaction networks and systems biology."
+dropdown = "Catalyst"
+
+[packages."Corleone.jl"]
+placement = "dropdown"
+category = "Modeling Languages"
+blurb = "Optimal control with SciML."
+dropdown = "Corleone"
+
+[packages."DiffEqFinancial.jl"]
+placement = "dropdown"
+category = "Modeling Languages"
+blurb = "Financial models (Heston, Black–Scholes, …) on DifferentialEquations."
+dropdown = "DiffEqFinancial"
+
+[packages."ModelingToolkit.jl"]
+placement = "dropdown"
+category = "Modeling Languages"
+blurb = "Acausal symbolic modeling."
+dropdown = "ModelingToolkit"
+
+[packages."MomentClosure.jl"]
+placement = "dropdown"
+category = "Modeling Languages"
+blurb = "Moment-closure equations for chemical master equations and SDEs."
+dropdown = "MomentClosure"
+
+[packages."NBodySimulator.jl"]
+placement = "dropdown"
+category = "Modeling Languages"
+blurb = "N-body, astrophysical, and molecular dynamics."
+dropdown = "NBodySimulator"
+
+[packages."ParameterizedFunctions.jl"]
+placement = "dropdown"
+category = "Modeling Languages"
+blurb = "Simple DSL for defining differential equations."
+dropdown = "ParameterizedFunctions"
+
+[packages."ProcessSimulator.jl"]
+placement = "dropdown"
+category = "Modeling Languages"
+blurb = "Process simulation on ModelingToolkit."
+dropdown = "ProcessSimulator"
+
+[packages."BipartiteGraphs.jl"]
+placement = "dropdown"
+category = "Numerical Utilities"
+blurb = "Bipartite graph types and utilities."
+dropdown = "BipartiteGraphs"
+
+[packages."ConcreteStructs.jl"]
+placement = "dropdown"
+category = "Numerical Utilities"
+blurb = "Macros for concrete struct field types."
+dropdown = "ConcreteStructs"
+
+[packages."DataInterpolations.jl"]
+placement = "dropdown"
+category = "Numerical Utilities"
+blurb = "1D interpolation and smoothing."
+dropdown = "DataInterpolations"
+
+[packages."DataInterpolationsND.jl"]
+placement = "dropdown"
+category = "Numerical Utilities"
+blurb = "N-dimensional interpolation on hyperrectangles."
+dropdown = "DataInterpolationsND"
+
+[packages."DiffEqNoiseProcess.jl"]
+placement = "dropdown"
+category = "Numerical Utilities"
+blurb = "Noise processes for SDEs and related solvers."
+dropdown = "DiffEqNoiseProcess"
+
+[packages."EllipsisNotation.jl"]
+placement = "dropdown"
+category = "Numerical Utilities"
+blurb = "`..` ellipsis indexing."
+dropdown = "EllipsisNotation"
+
+[packages."ExponentialUtilities.jl"]
+placement = "dropdown"
+category = "Numerical Utilities"
+blurb = "Matrix exponentials, KIOPS, expmv, φ-functions."
+dropdown = "ExponentialUtilities"
+
+[packages."FastAlmostBandedMatrices.jl"]
+placement = "dropdown"
+category = "Numerical Utilities"
+blurb = "Almost-banded matrices (used by BoundaryValueDiffEq)."
+dropdown = "FastAlmostBandedMatrices"
+
+[packages."FastBroadcast.jl"]
+placement = "dropdown"
+category = "Numerical Utilities"
+blurb = "`@..` broadcast that compiles to tight loops."
+dropdown = "FastBroadcast"
+
+[packages."FindFirstFunctions.jl"]
+placement = "dropdown"
+category = "Numerical Utilities"
+blurb = "Faster specialized `findfirst`."
+dropdown = "FindFirstFunctions"
+
+[packages."FunctionWrappersWrappers.jl"]
+placement = "dropdown"
+category = "Numerical Utilities"
+blurb = "Double FunctionWrappers layer used in solver internals."
+dropdown = "FunctionWrappersWrappers"
+
+[packages."LHLFactorization.jl"]
+placement = "dropdown"
+category = "Numerical Utilities"
+blurb = "Hessenberg reduction for families of shifted linear systems."
+dropdown = "LHLFactorization"
+
+[packages."LightweightStats.jl"]
+placement = "dropdown"
+category = "Numerical Utilities"
+blurb = "Basic statistics with minimal dependencies."
+dropdown = "LightweightStats"
+
+[packages."MuladdMacro.jl"]
+placement = "dropdown"
+category = "Numerical Utilities"
+blurb = "`@muladd` fused multiply-add rewriting."
+dropdown = "MuladdMacro"
+
+[packages."PoissonRandom.jl"]
+placement = "dropdown"
+category = "Numerical Utilities"
+blurb = "Fast Poisson random numbers."
+dropdown = "PoissonRandom"
+
+[packages."PreallocationTools.jl"]
+placement = "dropdown"
+category = "Numerical Utilities"
+blurb = "Caches compatible with automatic differentiation."
+dropdown = "PreallocationTools"
+
+[packages."PureGebal.jl"]
+placement = "dropdown"
+category = "Numerical Utilities"
+blurb = "Pure-Julia LAPACK xGEBAL-style matrix balancing."
+dropdown = "PureGebal"
+
+[packages."PureKLU.jl"]
+placement = "dropdown"
+category = "Numerical Utilities"
+blurb = "Pure-Julia KLU sparse LU, no SuiteSparse_jll."
+dropdown = "PureKLU"
+
+[packages."PureUMFPACK.jl"]
+placement = "dropdown"
+category = "Numerical Utilities"
+blurb = "Pure-Julia UMFPACK-style sparse LU."
+dropdown = "PureUMFPACK"
+
+[packages."QuasiMonteCarlo.jl"]
+placement = "dropdown"
+category = "Numerical Utilities"
+blurb = "Quasi-Monte Carlo sequences."
+dropdown = "QuasiMonteCarlo"
+
+[packages."RespecializeParams.jl"]
+placement = "dropdown"
+category = "Numerical Utilities"
+blurb = "Type-stable opaque parameter containers for solvers."
+dropdown = "RespecializeParams"
+
+[packages."RootedTrees.jl"]
+placement = "dropdown"
+category = "Numerical Utilities"
+blurb = "Rooted trees and Runge–Kutta order conditions."
+dropdown = "RootedTrees"
+
+[packages."RuntimeGeneratedFunctions.jl"]
+placement = "dropdown"
+category = "Numerical Utilities"
+blurb = "Runtime-generated functions without world-age issues."
+dropdown = "RuntimeGeneratedFunctions"
+
+[packages."SparseBandedMatrices.jl"]
+placement = "dropdown"
+category = "Numerical Utilities"
+blurb = "Sparse banded matrices."
+dropdown = "SparseBandedMatrices"
+
+[packages."DiffEqOperators.jl"]
+placement = "dropdown"
+category = "PDE Solvers"
+blurb = "Archived FDM operator library; prefer MethodOfLines."
+dropdown = "DiffEqOperators"
+
+[packages."FEniCS.jl"]
+placement = "dropdown"
+category = "PDE Solvers"
+blurb = "FEniCS finite-element wrappers."
+dropdown = "FEniCS"
+
+[packages."FiniteVolumeMethod.jl"]
+placement = "dropdown"
+category = "PDE Solvers"
+blurb = "2D finite-volume method for conservation laws."
+dropdown = "FiniteVolumeMethod"
+
+[packages."FiniteVolumeMethod1D.jl"]
+placement = "dropdown"
+category = "PDE Solvers"
+blurb = "1D finite-volume method."
+dropdown = "FiniteVolumeMethod1D"
+
+[packages."HighDimPDE.jl"]
+placement = "dropdown"
+category = "PDE Solvers"
+blurb = "High-dimensional PDE solvers (Deep BSDE, Feynman–Kac)."
+dropdown = "HighDimPDE"
+
+[packages."MethodOfLines.jl"]
+placement = "dropdown"
+category = "PDE Solvers"
+blurb = "Automated finite-difference discretization of PDESystem."
+dropdown = "MethodOfLines"
+
+[packages."NeuralOperators.jl"]
+placement = "dropdown"
+category = "PDE Solvers"
+blurb = "Fourier neural operators, DeepONets, and related operator learning."
+dropdown = "NeuralOperators"
+
+[packages."NeuralPDE.jl"]
+placement = "dropdown"
+category = "PDE Solvers"
+blurb = "Physics-informed neural network PDE solvers."
+dropdown = "NeuralPDE"
+
+[packages."CatalystNetworkAnalysis.jl"]
+placement = "dropdown"
+category = "Parameter Analysis"
+blurb = "Network-analysis algorithms on Catalyst reaction networks."
+dropdown = "CatalystNetworkAnalysis"
+
+[packages."EasyModelAnalysis.jl"]
+placement = "dropdown"
+category = "Parameter Analysis"
+blurb = "High-level queries on simulation output."
+dropdown = "EasyModelAnalysis"
+
+[packages."GlobalSensitivity.jl"]
+placement = "dropdown"
+category = "Parameter Analysis"
+blurb = "Global sensitivity analysis (Sobol, Morris, eFAST, …)."
+dropdown = "GlobalSensitivity"
+
+[packages."MinimallyDisruptiveCurves.jl"]
+placement = "dropdown"
+category = "Parameter Analysis"
+blurb = "Curves in parameter space that leave the solution nearly unchanged."
+dropdown = "MinimallyDisruptiveCurves"
+
+[packages."StructuralIdentifiability.jl"]
+placement = "dropdown"
+category = "Parameter Analysis"
+blurb = "Structural identifiability of ODE models."
+dropdown = "StructuralIdentifiability"
+
+[packages."DataDrivenDiffEq.jl"]
+placement = "dropdown"
+category = "Symbolic Learning"
+blurb = "Data-driven dynamical systems and equation discovery."
+dropdown = "DataDrivenDiffEq"
+
+[packages."SymbolicNumericIntegration.jl"]
+placement = "dropdown"
+category = "Symbolic Learning"
+blurb = "Symbolic-numeric integration."
+dropdown = "SymbolicNumericIntegration"
+
+[packages."FunctionProperties.jl"]
+placement = "dropdown"
+category = "Symbolic Tools"
+blurb = "Detects function properties (branches, etc.) for compiler/AD optimizations."
+dropdown = "FunctionProperties"
+
+[packages."ModelOrderReduction.jl"]
+placement = "dropdown"
+category = "Symbolic Tools"
+blurb = "Automated model-order reduction on ModelingToolkit systems."
+dropdown = "ModelOrderReduction"
+
+[packages."SymbolicAnalysis.jl"]
+placement = "dropdown"
+category = "Symbolic Tools"
+blurb = "Disciplined-programming property propagation for optimization."
+dropdown = "SymbolicAnalysis"
+
+[packages."SymbolicLimits.jl"]
+placement = "dropdown"
+category = "Symbolic Tools"
+blurb = "Symbolic limits and zero-equivalence of log-exp functions."
+dropdown = "SymbolicLimits"
+
+[packages."OptimalUncertaintyQuantification.jl"]
+placement = "dropdown"
+category = "Uncertainty Quantification"
+blurb = "Bounds on expectations without a fully specified input distribution."
+dropdown = "OptimalUncertaintyQuantification"
+
+[packages."PolyChaos.jl"]
+placement = "dropdown"
+category = "Uncertainty Quantification"
+blurb = "Polynomial chaos expansions."
+dropdown = "PolyChaos"
+
+[packages."SciMLExpectations.jl"]
+placement = "dropdown"
+category = "Uncertainty Quantification"
+blurb = "Fast expectations of equation solutions."
+dropdown = "SciMLExpectations"
+
+[packages."DASKR.jl"]
+placement = "embedded"
+category = "Equation Solvers"
+blurb = "DASKR DAE solver wrapper."
+embedded_in = "DiffEqDocs"
+
+[packages."DASSL.jl"]
+placement = "embedded"
+category = "Equation Solvers"
+blurb = "DASSL BDF DAE solver."
+embedded_in = "DiffEqDocs"
+
+[packages."deSolveDiffEq.jl"]
+placement = "embedded"
+category = "Equation Solvers"
+blurb = "R deSolve wrappers on the SciML interface."
+embedded_in = "DiffEqDocs"
+
+[packages."DifferentialEquations.jl"]
+placement = "embedded"
+category = "Equation Solvers"
+blurb = "Umbrella DiffEq package; documented as DiffEqDocs."
+embedded_in = "DiffEqDocs"
+
+[packages."GeometricIntegratorsDiffEq.jl"]
+placement = "embedded"
+category = "Equation Solvers"
+blurb = "GeometricIntegrators.jl wrappers on the SciML interface."
+embedded_in = "DiffEqDocs"
+
+[packages."ODEInterfaceDiffEq.jl"]
+placement = "embedded"
+category = "Equation Solvers"
+blurb = "Hairer Fortran ODEInterface wrappers."
+embedded_in = "DiffEqDocs"
+
+[packages."SciPyDiffEq.jl"]
+placement = "embedded"
+category = "Equation Solvers"
+blurb = "SciPy ODE wrappers on the SciML interface."
+embedded_in = "DiffEqDocs"
+
+[packages."SimpleBoundaryValueDiffEq.jl"]
+placement = "embedded"
+category = "Equation Solvers"
+blurb = "Minimal BVP solvers."
+embedded_in = "DiffEqDocs"
+
+[packages."SimpleDiffEq.jl"]
+placement = "embedded"
+category = "Equation Solvers"
+blurb = "Minimal no-cruft ODE solvers."
+embedded_in = "DiffEqDocs"
+
+[packages."Sundials.jl"]
+placement = "embedded"
+category = "Equation Solvers"
+blurb = "CVODE, ARKODE, IDA, and KINSOL wrappers."
+embedded_in = "DiffEqDocs"
+
+[packages."SciMLTesting.jl"]
+placement = "overview"
+category = "Developer Documentation"
+blurb = "Shared GROUP-based test harness for SciML packages."
+
+[packages."BlackBoxOptim.jl"]
+placement = "overview"
+category = "Equation Solvers"
+blurb = "Derivative-free global/black-box optimization (OptimizationBBO)."
+
+[packages."ComplementaritySolve.jl"]
+placement = "overview"
+category = "Equation Solvers"
+blurb = "Complementarity problems with ChainRules-compatible gradients."
+
+[packages."ParallelParticleSwarms.jl"]
+placement = "overview"
+category = "Equation Solvers"
+blurb = "GPU-accelerated particle-swarm optimization."
+
+[packages."SpatialBranchAndBound.jl"]
+placement = "overview"
+category = "Equation Solvers"
+blurb = "Spatial branch-and-bound."
+
+[packages."YOLOWeights.jl"]
+placement = "overview"
+category = "Function Approximation"
+blurb = "Pinned, checksummed Ultralytics YOLO ONNX weights."
+
+[packages."SciMLPublic.jl"]
+placement = "overview"
+category = "High-Level Interfaces"
+blurb = "`@public` backport of Julia 1.11's `public` keyword."
+
+[packages."CasADi.jl"]
+placement = "overview"
+category = "Model Libraries and Importers"
+blurb = "CasADi interface via PythonCall (fork of ichatzinikolaidis/CasADi.jl)."
+
+[packages."DiffEqProblemLibrary.jl"]
+placement = "overview"
+category = "Model Libraries and Importers"
+blurb = "Premade DiffEq problems for examples and testing."
+
+[packages."PubChemReactions.jl"]
+placement = "overview"
+category = "Model Libraries and Importers"
+blurb = "Reaction-network generation from PubChem data."
+
+[packages."SBMLToolkitTestSuite.jl"]
+placement = "overview"
+category = "Model Libraries and Importers"
+blurb = "Runner for the SBML Test Suite against SBMLToolkit."
+
+[packages."BinaryHeaps.jl"]
+placement = "overview"
+category = "Numerical Utilities"
+blurb = "Invalidation-free binary heaps extracted from DataStructures.jl."
+
+[packages."CommonWorldInvalidations.jl"]
+placement = "overview"
+category = "Numerical Utilities"
+blurb = "Pre-invalidates common MethodError paths to cut latency."
+
+[packages."FastPower.jl"]
+placement = "overview"
+category = "Numerical Utilities"
+blurb = "Faster, slightly less accurate floating-point power."
+
+[packages."MaybeInplace.jl"]
+placement = "overview"
+category = "Numerical Utilities"
+blurb = "Bang-bang macros that pick in-place vs out-of-place by array mutability."
+
+[packages."ResettableStacks.jl"]
+placement = "overview"
+category = "Numerical Utilities"
+blurb = "Stacks with `reset!` that avoid GC in solver internals."
+
+[packages."SIMDRK.jl"]
+placement = "overview"
+category = "Numerical Utilities"
+blurb = "Generation of SIMD-compatible Runge–Kutta tableaus."
+
+[packages."SimpleNorm.jl"]
+placement = "overview"
+category = "Numerical Utilities"
+blurb = "`norm` without a LinearAlgebra/BLAS dependency."
+
+[packages."SparseColumnPivotedQR.jl"]
+placement = "overview"
+category = "Numerical Utilities"
+blurb = "Rank-revealing column-pivoted Householder QR for SparseMatrixCSR."
+
+[packages."SparseMatrixIdentification.jl"]
+placement = "overview"
+category = "Numerical Utilities"
+blurb = "Sparse matrix structure identification."
+
+[packages."SparseWithDenseRowColMatrices.jl"]
+placement = "overview"
+category = "Numerical Utilities"
+blurb = "Sparse plus dense row/column matrices with Sherman–Morrison–Woodbury."
+
+[packages."SpecializingFactorizations.jl"]
+placement = "overview"
+category = "Numerical Utilities"
+blurb = "Type-stable detection of dense-matrix structure with specialized factorizations."
+
+[packages."TupleLU.jl"]
+placement = "overview"
+category = "Numerical Utilities"
+blurb = "LU factorization on tuple-based small matrices."
+
+[packages."PDEBase.jl"]
+placement = "overview"
+category = "PDE Solvers"
+blurb = "Shared types and interface for ModelingToolkit PDE discretizers."
+
+[packages."PDESystemLibrary.jl"]
+placement = "overview"
+category = "PDE Solvers"
+blurb = "Library of ModelingToolkit PDESystem examples."
+
+[packages."DimensionalPlotRecipes.jl"]
+placement = "overview"
+category = "Plots and Visualization"
+blurb = "Plot recipes for high-dimensional numbers and reductions."
+
+[packages."DataCollocations.jl"]
+placement = "overview"
+category = "Symbolic Learning"
+blurb = "Non-parametric collocation for smoothing timeseries and estimating derivatives."
+
+[packages."2025-JuliaCon-DifferentialEquations-Workshop"]
+placement = "extra"
+category = "Extra Resources"
+blurb = "JuliaCon 2025 DifferentialEquations workshop."
+
+[packages."Catalyst_PLOS_COMPBIO_2023"]
+placement = "extra"
+category = "Extra Resources"
+blurb = "Companion notebooks for the 2023 Catalyst PLOS Comp Bio paper."
+
+[packages."GeiloInverseProblemWorkshop"]
+placement = "extra"
+category = "Extra Resources"
+blurb = "Geilo inverse-problems workshop notes."
+
+[packages."Julia_Modeling_Workshop"]
+placement = "extra"
+category = "Extra Resources"
+blurb = "High-performance scientific modeling workshop."
+
+[packages."ModelingToolkitWorkshop_JuliaCon2024"]
+placement = "extra"
+category = "Extra Resources"
+blurb = "JuliaCon 2024 ModelingToolkit workshop materials."
+
+[packages."Scientific_Modeling_Cheatsheet"]
+placement = "extra"
+category = "Extra Resources"
+blurb = "MATLAB / Python / Julia scientific-modeling cheatsheet."
+
+[packages."SciMLBenchmarks.jl"]
+placement = "extra"
+category = "Extra Resources"
+blurb = "Benchmark sources; rendered output is SciMLBenchmarksOutput."
+
+[packages."SciMLBook"]
+placement = "extra"
+category = "Extra Resources"
+blurb = "Parallel Computing and Scientific Machine Learning lecture notes (MIT 18.337)."
+
+[packages."diffeqpy"]
+placement = "extra"
+category = "Language Bindings"
+blurb = "Python bindings for DifferentialEquations.jl."
+
+[packages."diffeqr"]
+placement = "extra"
+category = "Language Bindings"
+blurb = "R bindings for DifferentialEquations.jl."
+
+[packages."juliatorch"]
+placement = "extra"
+category = "Language Bindings"
+blurb = "Wrap Julia functions as PyTorch autograd functions."
+
+[packages.".github"]
+placement = "infra"
+category = "Infrastructure"
+blurb = "Organization-wide GitHub Actions and metadata."
+
+[packages."demo-repository"]
+placement = "infra"
+category = "Infrastructure"
+blurb = "GitHub demo repository, not a SciML package."
+
+[packages."LinearSolveAutotuneResults.jl"]
+placement = "infra"
+category = "Infrastructure"
+blurb = "Stored LinearSolve autotune results, not a solver package."
+
+[packages."ModelDiscovery.jl"]
+placement = "infra"
+category = "Infrastructure"
+blurb = "Empty placeholder repository."
+
+[packages."OptimalUncertaintyQuantification-DEV.jl"]
+placement = "infra"
+category = "Infrastructure"
+blurb = "Development duplicate of OptimalUncertaintyQuantification.jl."
+
+[packages."PropertyModels.jl"]
+placement = "infra"
+category = "Infrastructure"
+blurb = "Empty placeholder repository."
+
+[packages."sciml.ai"]
+placement = "infra"
+category = "Infrastructure"
+blurb = "Organization website."
+
+[packages."SciMLAssets"]
+placement = "infra"
+category = "Infrastructure"
+blurb = "Shared website/assets."
+
+[packages."SciMLDocs"]
+placement = "infra"
+category = "Infrastructure"
+blurb = "This documentation aggregator (Home in the nav)."

--- a/docs/package_inventory.toml
+++ b/docs/package_inventory.toml
@@ -110,6 +110,12 @@ category = "Equation Solvers"
 blurb = "Deterministic and stochastic difference equations and state-space likelihoods."
 dropdown = "DifferenceEquations"
 
+[packages."Corleone.jl"]
+placement = "dropdown"
+category = "Equation Solvers"
+blurb = "Optimal control with SciML."
+dropdown = "Corleone"
+
 [packages."Evolutionary.jl"]
 placement = "dropdown"
 category = "Equation Solvers"
@@ -374,15 +380,9 @@ category = "Modeling Languages"
 blurb = "Chemical reaction networks and systems biology."
 dropdown = "Catalyst"
 
-[packages."Corleone.jl"]
-placement = "dropdown"
-category = "Modeling Languages"
-blurb = "Optimal control with SciML."
-dropdown = "Corleone"
-
 [packages."DiffEqFinancial.jl"]
 placement = "dropdown"
-category = "Modeling Languages"
+category = "Model Libraries and Importers"
 blurb = "Financial models (Heston, Black–Scholes, …) on DifferentialEquations."
 dropdown = "DiffEqFinancial"
 

--- a/docs/src/highlevels/developer_documentation.md
+++ b/docs/src/highlevels/developer_documentation.md
@@ -49,6 +49,17 @@ StochasticDiffEq.jl, and DelayDiffEq.jl. This section of the documentation descr
 internal systems of these packages and how they are used to quickly write efficient
 solvers.
 
+## SciMLTesting.jl: Shared Test Harness
+
+[SciMLTesting.jl](https://github.com/SciML/SciMLTesting.jl) is the shared `GROUP`-based
+test runner used across SciML packages (Aqua, ExplicitImports, JET, and the curated `"All"`
+subset).
+
+## OrgMaintenanceScripts.jl: Organization Maintenance
+
+[OrgMaintenanceScripts.jl](https://github.com/SciML/OrgMaintenanceScripts.jl) collects
+scripts used to maintain the SciML GitHub organization.
+
 # Third-Party Libraries to Note
 
 ## Documenter.jl

--- a/docs/src/highlevels/equation_solvers.md
+++ b/docs/src/highlevels/equation_solvers.md
@@ -192,6 +192,11 @@ black-box methods such as differential evolution. Both are available through Opt
 from its sparsity pattern and recommends UMFPACK, KLU, or Pardiso. It is a companion to
 LinearSolve.jl rather than a replacement for the `LinearProblem` interface.
 
+## Corleone.jl: Optimal Control
+
+[Corleone.jl](https://github.com/SciML/Corleone.jl) is an optimal-control solver that composes with
+the SciML equation-solver stack.
+
 ## Differential Equation Solver Packages (including those documented in DiffEqDocs)
 
 OrdinaryDiffEq.jl, BoundaryValueDiffEq.jl, and DiffEqGPU.jl have their own Documenter sites

--- a/docs/src/highlevels/equation_solvers.md
+++ b/docs/src/highlevels/equation_solvers.md
@@ -93,8 +93,8 @@ for solving `OptimizationProblem`s. It includes wrappers of most of the Julia no
 optimization ecosystem, allowing one syntax to use all packages in a uniform manner. This
 covers:
 
-  - OptimizationBBO for [BlackBoxOptim.jl](https://github.com/robertfeldt/BlackBoxOptim.jl)
-  - OptimizationEvolutionary for [Evolutionary.jl](https://github.com/wildart/Evolutionary.jl)
+  - OptimizationBBO for [BlackBoxOptim.jl](https://github.com/SciML/BlackBoxOptim.jl)
+  - OptimizationEvolutionary for [Evolutionary.jl](https://github.com/SciML/Evolutionary.jl)
   - OptimizationGCMAES for [GCMAES.jl](https://github.com/AStupidBear/GCMAES.jl)
   - OptimizationMOI for [MathOptInterface.jl](https://github.com/jump-dev/MathOptInterface.jl)
     (usage of algorithm via MathOptInterface API; see also the API
@@ -164,6 +164,56 @@ and differential equations driven by Levy processes.
 
 In addition, JumpProcesses's interfaces allow for solving with regular jump methods,
 such as adaptive Tau-Leaping.
+
+## DifferenceEquations.jl: Deterministic and Stochastic Difference Equations
+
+[DifferenceEquations.jl](https://github.com/SciML/DifferenceEquations.jl) solves initial-value
+problems for deterministic and stochastic difference equations, including models with a
+separate observation equation. It also provides likelihoods for standard filters used to
+estimate state-space models.
+
+## LineSearch.jl: Unified Line Search Interface
+
+[LineSearch.jl](https://github.com/SciML/LineSearch.jl) is a common interface over Julia line
+search algorithms, including its own high-performance methods. NonlinearSolve.jl and related
+solvers use it to swap line search implementations without changing the rest of the solver
+stack.
+
+## Evolutionary.jl and BlackBoxOptim.jl: Derivative-Free Global Optimization
+
+[Evolutionary.jl](https://github.com/SciML/Evolutionary.jl) implements evolutionary and genetic
+algorithms. [BlackBoxOptim.jl](https://github.com/SciML/BlackBoxOptim.jl) implements stochastic
+black-box methods such as differential evolution. Both are available through Optimization.jl
+(`OptimizationEvolutionary`, `OptimizationBBO`) and can be used directly.
+
+## NeuralLinearSolve.jl: Learned Sparse Direct-Solver Selection
+
+[NeuralLinearSolve.jl](https://github.com/SciML/NeuralLinearSolve.jl) classifies a sparse matrix
+from its sparsity pattern and recommends UMFPACK, KLU, or Pardiso. It is a companion to
+LinearSolve.jl rather than a replacement for the `LinearProblem` interface.
+
+## Differential Equation Solver Packages (including those documented in DiffEqDocs)
+
+OrdinaryDiffEq.jl, BoundaryValueDiffEq.jl, and DiffEqGPU.jl have their own Documenter sites
+and also appear under Advanced Solver APIs in the top navigation. Many other DiffEq solver
+packages document their algorithms inside
+[DiffEqDocs](https://docs.sciml.ai/DiffEqDocs/stable/) instead of a second standalone site:
+
+  - [Sundials.jl](https://github.com/SciML/Sundials.jl) — CVODE, ARKODE, IDA, and KINSOL
+  - [DASKR.jl](https://github.com/SciML/DASKR.jl) and [DASSL.jl](https://github.com/SciML/DASSL.jl) — classic DAE codes
+  - [ODEInterfaceDiffEq.jl](https://github.com/SciML/ODEInterfaceDiffEq.jl) — Hairer's Fortran solvers
+  - [SimpleDiffEq.jl](https://github.com/SciML/SimpleDiffEq.jl) and [SimpleBoundaryValueDiffEq.jl](https://github.com/SciML/SimpleBoundaryValueDiffEq.jl) — minimal solvers without events or extra features
+  - [MATLABDiffEq.jl](https://github.com/SciML/MATLABDiffEq.jl), [SciPyDiffEq.jl](https://github.com/SciML/SciPyDiffEq.jl), and [deSolveDiffEq.jl](https://github.com/SciML/deSolveDiffEq.jl) — wrappers for MATLAB, SciPy, and R deSolve on the SciML interface
+  - [GeometricIntegratorsDiffEq.jl](https://github.com/SciML/GeometricIntegratorsDiffEq.jl) — GeometricIntegrators.jl wrappers
+  - [SteadyStateDiffEq.jl](https://github.com/SciML/SteadyStateDiffEq.jl) — steady-state solvers
+  - [OrdinaryDiffEqOperatorSplitting.jl](https://github.com/SciML/OrdinaryDiffEqOperatorSplitting.jl) — operator splitting for split ODE/DAE formulations
+  - [IRKGaussLegendre.jl](https://github.com/SciML/IRKGaussLegendre.jl) — 16th-order implicit Runge–Kutta Gauss–Legendre
+  - [QuantumNLDiffEq.jl](https://github.com/SciML/QuantumNLDiffEq.jl) — differential quantum circuits for nonlinear DEs
+  - [ComplementaritySolve.jl](https://github.com/SciML/ComplementaritySolve.jl) — complementarity problems with ChainRules-compatible gradients
+  - [ParallelParticleSwarms.jl](https://github.com/SciML/ParallelParticleSwarms.jl) — GPU-accelerated particle swarm optimization
+
+The full list of SciML repositories and where each one is documented is in the
+[Package Index](@ref package_index).
 
 # Third-Party Libraries to Note
 

--- a/docs/src/highlevels/implicit_layers.md
+++ b/docs/src/highlevels/implicit_layers.md
@@ -29,3 +29,8 @@ is a library of optimized layer implementations for Deep Equilibrium Models (DEQ
 special training techniques such as implicit-explicit regularization in order to accelerate
 the convergence over traditional implementations, all while using the optimized and flexible
 SciML libraries under the hood.
+
+## NeuralLyapunov.jl: Neural Lyapunov Functions
+
+[NeuralLyapunov.jl](https://github.com/SciML/NeuralLyapunov.jl) searches for Lyapunov functions
+parameterized by neural networks, using SciML solvers and Optimization.jl.

--- a/docs/src/highlevels/interfaces.md
+++ b/docs/src/highlevels/interfaces.md
@@ -29,6 +29,43 @@ equation solvers. It's defined as an extremely lightweight library so that other
 ecosystems can build on the same `solve` definition without clashing with SciML
 when both export.
 
+## SciMLStructures.jl: Queryable Parameter and User-Data Layouts
+
+[SciMLStructures.jl](https://github.com/SciML/SciMLStructures.jl) defines how solvers and
+estimation tools read and write fields of user parameter objects without depending on a
+single concrete type.
+
+## SciMLLogging.jl: Verbosity Control
+
+[SciMLLogging.jl](https://github.com/SciML/SciMLLogging.jl) is the shared verbosity and
+logging system for SciML solvers.
+
+## ADTypes.jl: Automatic Differentiation Backend Types
+
+[ADTypes.jl](https://github.com/SciML/ADTypes.jl) is a multi-valued choice of automatic
+differentiation backend and its options, used across SciML and JuliaDiff.
+
+## SymbolicIndexingInterface.jl: Symbolic Indexing of SciML Objects
+
+[SymbolicIndexingInterface.jl](https://github.com/SciML/SymbolicIndexingInterface.jl)
+is the interface for indexing solutions, integrators, and problems by symbolic variables
+defined in DSLs such as ModelingToolkit and Catalyst.
+
+## SurrogatesBase.jl: Surrogate Model API
+
+[SurrogatesBase.jl](https://github.com/SciML/SurrogatesBase.jl) is the shared API for
+deterministic and stochastic surrogates used by Surrogates.jl.
+
+## SciMLIterators.jl: Iterators over Solutions and Integrators
+
+[SciMLIterators.jl](https://github.com/SciML/SciMLIterators.jl) provides convenience
+iterators for stepping through SciML solutions and integrators.
+
+## SciMLPublic.jl: The `@public` Compatibility Shim
+
+[SciMLPublic.jl](https://github.com/SciML/SciMLPublic.jl) backports Julia 1.11's `public`
+keyword so packages can mark API as public without exporting it.
+
 ## Static.jl: A Shared Interface for Static Compile-Time Computation
 
 [Static.jl](https://github.com/SciML/Static.jl) is a set of statically parameterized types

--- a/docs/src/highlevels/inverse_problems.md
+++ b/docs/src/highlevels/inverse_problems.md
@@ -11,6 +11,7 @@ present the relevant packages that facilitate parameter estimation, namely:
   - [DataDrivenDiffEq.jl](https://docs.sciml.ai/DataDrivenDiffEq/stable/)
   - [DiffEqParamEstim.jl](https://docs.sciml.ai/DiffEqParamEstim/)
   - [DiffEqBayes.jl](https://docs.sciml.ai/DiffEqBayes/)
+  - [CurveFit.jl](https://docs.sciml.ai/CurveFit/stable/)
 
 We also provide information regarding the respective strengths of these packages
 so that you can easily decide which one suits your needs best.
@@ -62,6 +63,17 @@ conjunction with [Turing.jl](https://turinglang.org/),
 as flexible as direct usage of DiffEqFlux.jl or Turing.jl, DiffEqBayes.jl can
 be an approachable interface for those not familiar with Bayesian estimation,
 and provides a nice way to use Stan from pure Julia.
+
+## CurveFit.jl: Least Squares and Curve Fitting
+
+[CurveFit.jl](https://github.com/SciML/CurveFit.jl) provides linear, polynomial, special-function,
+and nonlinear least-squares fitting on the CommonSolve `solve` interface.
+
+## DataCollocations.jl: Smoothing and Derivative Estimation
+
+[DataCollocations.jl](https://github.com/SciML/DataCollocations.jl) is non-parametric collocation
+for smoothing timeseries and estimating derivatives, used as a preprocessing step for equation
+discovery and parameter estimation.
 
 # Third-Party Tools of Note
 

--- a/docs/src/highlevels/learning_resources.md
+++ b/docs/src/highlevels/learning_resources.md
@@ -24,6 +24,28 @@ It contains a walkthrough of many of the methods implemented in the SciML librar
 of the functionality at a deeper level. This course was intended for MIT graduate students in engineering, computer science,
 and mathematics and thus may have a high prerequisite requirement than many other resources.
 
+## Scientific Modeling Cheatsheet
+
+The [Scientific Modeling Cheatsheet](https://github.com/SciML/Scientific_Modeling_Cheatsheet)
+is a MATLAB / Python / Julia quick reference for common scientific-modeling tasks.
+
+## Workshops
+
+Workshop materials in the SciML organization include:
+
+  - [SciMLWorkshop.jl](https://github.com/SciML/SciMLWorkshop.jl)
+  - [ModelingToolkitCourse](https://github.com/SciML/ModelingToolkitCourse)
+  - [2025 JuliaCon DifferentialEquations Workshop](https://github.com/SciML/2025-JuliaCon-DifferentialEquations-Workshop)
+  - [ModelingToolkit workshop at JuliaCon 2024](https://github.com/SciML/ModelingToolkitWorkshop_JuliaCon2024)
+  - [Geilo Inverse Problem Workshop](https://github.com/SciML/GeiloInverseProblemWorkshop)
+  - [Julia Modeling Workshop](https://github.com/SciML/Julia_Modeling_Workshop)
+
+## Language bindings
+
+  - [diffeqpy](https://github.com/SciML/diffeqpy) — DifferentialEquations.jl from Python
+  - [diffeqr](https://github.com/SciML/diffeqr) — DifferentialEquations.jl from R
+  - [juliatorch](https://github.com/SciML/juliatorch) — Julia functions as PyTorch autograd functions
+
 ## sir-julia: Various implementations of the classical SIR model in Julia
 
 For those who like to learn by example, the repository [sir-julia](https://github.com/epirecipes/sir-julia) is a great

--- a/docs/src/highlevels/model_libraries_and_importers.md
+++ b/docs/src/highlevels/model_libraries_and_importers.md
@@ -63,6 +63,12 @@ Julia objects and converts them to ModelingToolkit systems.
 [DiffEqPhysics.jl](https://github.com/SciML/DiffEqPhysics.jl) builds differential-equation
 problems from physical descriptions such as Hamiltonians, for use with the DiffEq solvers.
 
+## DiffEqFinancial.jl: Financial Models
+
+The goal of [DiffEqFinancial.jl](https://github.com/SciML/DiffEqFinancial.jl/) is to be a feature-complete set
+of models for the types of problems found in libraries like QuantLib, such as the Heston process or the
+Black-Scholes model.
+
 ## PubChem.jl and PubChemReactions.jl: Chemical Data Import
 
 [PubChem.jl](https://github.com/SciML/PubChem.jl) attaches PubChem metadata to Catalyst species.

--- a/docs/src/highlevels/model_libraries_and_importers.md
+++ b/docs/src/highlevels/model_libraries_and_importers.md
@@ -45,3 +45,40 @@ There are several hundred biological models available in the
 [ReactionNetworkImporters.jl](https://github.com/SciML/ReactionNetworkImporters.jl) is a library
 for reading [BioNetGen .net files](https://bionetgen.org/) and various stoichiometry matrix representations
 into the standard formats for Catalyst.jl and ModelingToolkit.jl.
+
+## ModelingToolkitNeuralNets.jl: Neural Network Blocks in Acausal Models
+
+[ModelingToolkitNeuralNets.jl](https://github.com/SciML/ModelingToolkitNeuralNets.jl) provides
+neural-network components in the style of ModelingToolkitStandardLibrary, so a universal
+differential equation can be wired into part of an `ODESystem` through `RealInputArray` /
+`RealOutputArray` connectors.
+
+## BaseModelica.jl: Base Modelica Import
+
+[BaseModelica.jl](https://github.com/SciML/BaseModelica.jl) parses Base Modelica models into
+Julia objects and converts them to ModelingToolkit systems.
+
+## DiffEqPhysics.jl: Hamiltonian and Physics-Based Problem Constructors
+
+[DiffEqPhysics.jl](https://github.com/SciML/DiffEqPhysics.jl) builds differential-equation
+problems from physical descriptions such as Hamiltonians, for use with the DiffEq solvers.
+
+## PubChem.jl and PubChemReactions.jl: Chemical Data Import
+
+[PubChem.jl](https://github.com/SciML/PubChem.jl) attaches PubChem metadata to Catalyst species.
+[PubChemReactions.jl](https://github.com/SciML/PubChemReactions.jl) generates reaction networks
+from PubChem data.
+
+## Pyomo.jl: Pyomo via Symbolics.jl
+
+[Pyomo.jl](https://github.com/SciML/Pyomo.jl) is a Julia interface to Pyomo that builds
+expressions through Symbolics.jl, so nonlinear optimization and DAE models defined in Pyomo
+can interoperate with the Julia symbolic stack.
+
+## MathML.jl: MathML Parser
+
+[MathML.jl](https://github.com/SciML/MathML.jl) parses MathML into Symbolics.jl expressions.
+
+## CasADi.jl: CasADi Interface
+
+[CasADi.jl](https://github.com/SciML/CasADi.jl) is a Julia interface to CasADi via PythonCall.

--- a/docs/src/highlevels/modeling_languages.md
+++ b/docs/src/highlevels/modeling_languages.md
@@ -60,16 +60,26 @@ Black-Scholes model.
 
 This image that went viral is actually runnable code from [ParameterizedFunctions.jl](https://docs.sciml.ai/ParameterizedFunctions/stable/). Define equations and models using a very simple high-level syntax and let the code generation tools build symbolic fast Jacobian, gradient, etc. functions for you.
 
-# Third-Party Tools of Note
-
 ## MomentClosure.jl: Automated Generation of Moment Closure Equations
 
-[MomentClosure.jl](https://github.com/augustinas1/MomentClosure.jl) is a library for generating the moment
+[MomentClosure.jl](https://github.com/SciML/MomentClosure.jl) is a library for generating the moment
 closure equations for a given chemical master equation or stochastic differential equation. Thus instead of
 solving a stochastic model thousands of times to find the mean and variance, this library can generate the
 deterministic equations for how the mean and variance evolve in order to be solved in a single run. MomentClosure.jl
 uses Catalyst `ReactionSystem` and ModelingToolkit `SDESystem` types as the input for its symbolic generation
 processes.
+
+## Corleone.jl: Optimal Control
+
+[Corleone.jl](https://github.com/SciML/Corleone.jl) connects optimal control to the SciML solver and
+modeling stack.
+
+## ProcessSimulator.jl: Process Simulation
+
+[ProcessSimulator.jl](https://github.com/SciML/ProcessSimulator.jl) is a process-simulation library
+built on ModelingToolkit.
+
+# Third-Party Tools of Note
 
 ## Agents.jl: Agent-Based Modeling Framework in Julia
 

--- a/docs/src/highlevels/modeling_languages.md
+++ b/docs/src/highlevels/modeling_languages.md
@@ -48,12 +48,6 @@ including astrophysical and molecular dynamics. It uses the DifferentialEquation
 choose between a large variety of symplectic integration schemes. It implements many of the thermostats required for
 doing standard molecular dynamics approximations.
 
-## DiffEqFinancial.jl: Financial models for use in the DifferentialEquations ecosystem
-
-The goal of [DiffEqFinancial.jl](https://github.com/SciML/DiffEqFinancial.jl/) is to be a feature-complete set
-of solvers for the types of problems found in libraries like QuantLib, such as the Heston process or the
-Black-Scholes model.
-
 ## ParameterizedFunctions.jl: Simple Differential Equation Definitions Made Easy
 
 ![](https://user-images.githubusercontent.com/1814174/172001045-b9e35b8d-0d40-41af-b606-95b81bb1194d.png)
@@ -68,11 +62,6 @@ solving a stochastic model thousands of times to find the mean and variance, thi
 deterministic equations for how the mean and variance evolve in order to be solved in a single run. MomentClosure.jl
 uses Catalyst `ReactionSystem` and ModelingToolkit `SDESystem` types as the input for its symbolic generation
 processes.
-
-## Corleone.jl: Optimal Control
-
-[Corleone.jl](https://github.com/SciML/Corleone.jl) connects optimal control to the SciML solver and
-modeling stack.
 
 ## ProcessSimulator.jl: Process Simulation
 

--- a/docs/src/highlevels/numerical_utilities.md
+++ b/docs/src/highlevels/numerical_utilities.md
@@ -61,6 +61,12 @@ methods and regression techniques for handling noisy data. Its methods include:
 
 These interpolations match the SciML interfaces and have direct support for packages like ModelingToolkit.jl.
 
+## DataInterpolationsND.jl: High-Dimensional Interpolation
+
+[DataInterpolationsND.jl](https://github.com/SciML/DataInterpolationsND.jl) interpolates
+arbitrarily high-dimensional array data on a hyperrectangle, including batched evaluation
+through KernelAbstractions.jl. For 1D data, use DataInterpolations.jl.
+
 ## PoissonRandom.jl: Fast Poisson Random Number Generation
 
 [PoissonRandom.jl](https://github.com/SciML/PoissonRandom.jl) is just fast Poisson random number generation
@@ -83,6 +89,29 @@ such as ModelingToolkit.jl to allow for runtime code generation for improved per
 array slicing notation for Julia. It uses `..` as a catch-all for “all dimensions”, allowing for indexing
 like `[..,1]` to mean `[:,:,:,1]` on four dimensional arrays, in a way that is generic to the number
 of dimensions in the underlying array.
+
+## MuladdMacro.jl, FindFirstFunctions.jl, and BipartiteGraphs.jl
+
+[MuladdMacro.jl](https://github.com/SciML/MuladdMacro.jl) rewrites multiplications and additions
+into `muladd`/`fma` calls. [FindFirstFunctions.jl](https://github.com/SciML/FindFirstFunctions.jl)
+specializes `findfirst` on dense vectors. [BipartiteGraphs.jl](https://github.com/SciML/BipartiteGraphs.jl)
+provides bipartite graph types used by symbolic tearing and related structural algorithms.
+
+## Additional Numerical Utilities
+
+These libraries support solver internals and high-performance kernels. They appear in the
+top navigation under Developer Tools → Numerical Utilities when they have an independent
+Documenter site; otherwise they are listed only in the [Package Index](@ref package_index).
+
+  - [FastBroadcast.jl](https://github.com/SciML/FastBroadcast.jl) — `@..` broadcast that compiles to loops
+  - [FastPower.jl](https://github.com/SciML/FastPower.jl) — faster, slightly less accurate `^`
+  - [FastAlmostBandedMatrices.jl](https://github.com/SciML/FastAlmostBandedMatrices.jl) — almost-banded matrices, used by BoundaryValueDiffEq
+  - [SparseBandedMatrices.jl](https://github.com/SciML/SparseBandedMatrices.jl) — sparse banded matrices
+  - [PureKLU.jl](https://github.com/SciML/PureKLU.jl), [PureUMFPACK.jl](https://github.com/SciML/PureUMFPACK.jl), [PureGebal.jl](https://github.com/SciML/PureGebal.jl) — pure-Julia KLU, UMFPACK-style LU, and matrix balancing
+  - [LHLFactorization.jl](https://github.com/SciML/LHLFactorization.jl) — Hessenberg reduction for shifted linear systems
+  - [RootedTrees.jl](https://github.com/SciML/RootedTrees.jl) — rooted trees and Runge–Kutta order conditions
+  - [ConcreteStructs.jl](https://github.com/SciML/ConcreteStructs.jl), [MaybeInplace.jl](https://github.com/SciML/MaybeInplace.jl), [RespecializeParams.jl](https://github.com/SciML/RespecializeParams.jl), [FunctionWrappersWrappers.jl](https://github.com/SciML/FunctionWrappersWrappers.jl) — type-stability and in-place/out-of-place helpers
+  - [BinaryHeaps.jl](https://github.com/SciML/BinaryHeaps.jl), [ResettableStacks.jl](https://github.com/SciML/ResettableStacks.jl), [LightweightStats.jl](https://github.com/SciML/LightweightStats.jl), [SimpleNorm.jl](https://github.com/SciML/SimpleNorm.jl), [CommonWorldInvalidations.jl](https://github.com/SciML/CommonWorldInvalidations.jl)
 
 # Third-Party Libraries to Note
 

--- a/docs/src/highlevels/package_index.md
+++ b/docs/src/highlevels/package_index.md
@@ -1,0 +1,350 @@
+# [SciML Package Index](@id package_index)
+
+This page is the complete inventory of non-archived repositories in the
+[SciML GitHub organization](https://github.com/SciML), plus a few archived
+docs sites that are still published (DiffEqDevDocs, SciMLTutorialsOutput,
+DiffEqOperators). Every package has a place here. Packages with their own
+Documenter site appear in the **top navigation bar** of [docs.sciml.ai](https://docs.sciml.ai).
+Some solver packages (OrdinaryDiffEq, Sundials, …) ship their API pages inside
+[DiffEqDocs](https://docs.sciml.ai/DiffEqDocs/stable/); that is the intended home
+for those docs rather than a second copy in the navigation bar.
+
+| Placement | Meaning |
+| --- | --- |
+| dropdown | Top navigation (independent docs) |
+| embedded | Embedded in another docs site |
+| overview | Overview pages (no independent docs site yet) |
+| extra | Learning resources / language bindings |
+| infra | Not a user-facing package |
+
+## Top navigation (independent docs)
+
+### Advanced Solver APIs
+
+| Package | Where | Summary |
+| --- | --- | --- |
+| [BoundaryValueDiffEq.jl](https://github.com/SciML/BoundaryValueDiffEq.jl) | Navigation → Advanced Solver APIs | Boundary-value problem solvers. |
+| [DiffEqGPU.jl](https://github.com/SciML/DiffEqGPU.jl) | Navigation → Advanced Solver APIs | GPU ensemble acceleration for DiffEq. |
+| [IRKGaussLegendre.jl](https://github.com/SciML/IRKGaussLegendre.jl) | Navigation → Advanced Solver APIs | 16th-order implicit RK Gauss–Legendre. |
+| [MATLABDiffEq.jl](https://github.com/SciML/MATLABDiffEq.jl) | Navigation → Advanced Solver APIs | MATLAB ODE solver wrappers on the SciML interface. |
+| [OrdinaryDiffEq.jl](https://github.com/SciML/OrdinaryDiffEq.jl) | Navigation → Advanced Solver APIs | High-performance ODE/DAE solvers; API also embedded in DiffEqDocs. |
+| [OrdinaryDiffEqOperatorSplitting.jl](https://github.com/SciML/OrdinaryDiffEqOperatorSplitting.jl) | Navigation → Advanced Solver APIs | Operator-splitting solvers for split ODE/DAE formulations. |
+| [QuantumNLDiffEq.jl](https://github.com/SciML/QuantumNLDiffEq.jl) | Navigation → Advanced Solver APIs | Differential quantum circuits for nonlinear DEs. |
+| [SteadyStateDiffEq.jl](https://github.com/SciML/SteadyStateDiffEq.jl) | Navigation → Advanced Solver APIs | Steady-state solvers for DiffEq; API also in DiffEqDocs. |
+
+### Array Libraries
+
+| Package | Where | Summary |
+| --- | --- | --- |
+| [ComponentArrays.jl](https://github.com/SciML/ComponentArrays.jl) | Navigation → Array Libraries | Arrays with arbitrarily nested named components. |
+| [LabelledArrays.jl](https://github.com/SciML/LabelledArrays.jl) | Navigation → Array Libraries | Named elements on arrays without overhead. |
+| [MultiScaleArrays.jl](https://github.com/SciML/MultiScaleArrays.jl) | Navigation → Array Libraries | Multiscale array types that compose with equation solvers. |
+| [RecursiveArrayTools.jl](https://github.com/SciML/RecursiveArrayTools.jl) | Navigation → Array Libraries | Nested arrays compatible with SciML solvers. |
+
+### Developer Documentation
+
+| Package | Where | Summary |
+| --- | --- | --- |
+| [ColPrac](https://github.com/SciML/ColPrac) | Navigation → Developer Documentation | Collaborative practices for community packages. |
+| [DiffEqDevDocs.jl](https://github.com/SciML/DiffEqDevDocs.jl) | Navigation → Developer Documentation | DiffEq developer documentation (archived repo, still published). |
+| [OrgMaintenanceScripts.jl](https://github.com/SciML/OrgMaintenanceScripts.jl) | Navigation → Developer Documentation | Scripts for maintaining a large GitHub organization. |
+| [SciMLStyle](https://github.com/SciML/SciMLStyle) | Navigation → Developer Documentation | SciML Julia style guide. |
+
+### Equation Solvers
+
+| Package | Where | Summary |
+| --- | --- | --- |
+| [DiffEqDocs.jl](https://github.com/SciML/DiffEqDocs.jl) | Navigation → Equation Solvers | DifferentialEquations.jl documentation (umbrella for the DiffEq solvers). |
+| [DifferenceEquations.jl](https://github.com/SciML/DifferenceEquations.jl) | Navigation → Equation Solvers | Deterministic and stochastic difference equations and state-space likelihoods. |
+| [Evolutionary.jl](https://github.com/SciML/Evolutionary.jl) | Navigation → Equation Solvers | Evolutionary and genetic algorithms. |
+| [Integrals.jl](https://github.com/SciML/Integrals.jl) | Navigation → Equation Solvers | Unified interface for quadrature. |
+| [JumpProcesses.jl](https://github.com/SciML/JumpProcesses.jl) | Navigation → Equation Solvers | Jump processes, Gillespie SSAs, and jump-diffusions. |
+| [LinearSolve.jl](https://github.com/SciML/LinearSolve.jl) | Navigation → Equation Solvers | Unified interface for linear solvers. |
+| [LineSearch.jl](https://github.com/SciML/LineSearch.jl) | Navigation → Equation Solvers | Unified line-search interface. |
+| [NeuralLinearSolve.jl](https://github.com/SciML/NeuralLinearSolve.jl) | Navigation → Equation Solvers | CNN that picks UMFPACK/KLU/Pardiso for a sparse matrix. |
+| [NonlinearSolve.jl](https://github.com/SciML/NonlinearSolve.jl) | Navigation → Equation Solvers | Unified interface for nonlinear solvers and bracketing. |
+| [Optimization.jl](https://github.com/SciML/Optimization.jl) | Navigation → Equation Solvers | Unified interface for mathematical optimization. |
+
+### Extra Resources
+
+| Package | Where | Summary |
+| --- | --- | --- |
+| [ModelingToolkitCourse](https://github.com/SciML/ModelingToolkitCourse) | Navigation → Extra Resources | ModelingToolkit course notes. |
+| [SciMLBenchmarksOutput](https://github.com/SciML/SciMLBenchmarksOutput) | Navigation → Extra Resources | Rendered SciML benchmarks site. |
+| [SciMLTutorialsOutput](https://github.com/SciML/SciMLTutorialsOutput) | Navigation → Extra Resources | Rendered extended tutorials (archived repo, still published). |
+| [SciMLWorkshop.jl](https://github.com/SciML/SciMLWorkshop.jl) | Navigation → Extra Resources | Workshop materials for SciML training. |
+
+### Function Approximation
+
+| Package | Where | Summary |
+| --- | --- | --- |
+| [ReservoirComputing.jl](https://github.com/SciML/ReservoirComputing.jl) | Navigation → Function Approximation | Reservoir computing. |
+| [Surrogates.jl](https://github.com/SciML/Surrogates.jl) | Navigation → Function Approximation | Surrogate modeling and optimization. |
+
+### High-Level Interfaces
+
+| Package | Where | Summary |
+| --- | --- | --- |
+| [ADTypes.jl](https://github.com/SciML/ADTypes.jl) | Navigation → High-Level Interfaces | Automatic-differentiation backend types. |
+| [CommonSolve.jl](https://github.com/SciML/CommonSolve.jl) | Navigation → High-Level Interfaces | Shared `solve` / `init` / `solve!` definition. |
+| [SciMLBase.jl](https://github.com/SciML/SciMLBase.jl) | Navigation → High-Level Interfaces | Core SciML problem/algorithm/solution interfaces. |
+| [SciMLIterators.jl](https://github.com/SciML/SciMLIterators.jl) | Navigation → High-Level Interfaces | Iterators over SciML solutions and integrators. |
+| [SciMLLogging.jl](https://github.com/SciML/SciMLLogging.jl) | Navigation → High-Level Interfaces | Verbosity and logging for SciML solvers. |
+| [SciMLOperators.jl](https://github.com/SciML/SciMLOperators.jl) | Navigation → High-Level Interfaces | Matrix-free linear and affine operators. |
+| [SciMLStructures.jl](https://github.com/SciML/SciMLStructures.jl) | Navigation → High-Level Interfaces | Queryable structure interface for user data and parameters. |
+| [Static.jl](https://github.com/SciML/Static.jl) | Navigation → High-Level Interfaces | Statically parameterized types for compile-time computation. |
+| [SurrogatesBase.jl](https://github.com/SciML/SurrogatesBase.jl) | Navigation → High-Level Interfaces | API for deterministic and stochastic surrogates. |
+| [SymbolicIndexingInterface.jl](https://github.com/SciML/SymbolicIndexingInterface.jl) | Navigation → High-Level Interfaces | Symbolic indexing of SciML objects. |
+
+### Implicit Layer Deep Learning
+
+| Package | Where | Summary |
+| --- | --- | --- |
+| [DeepEquilibriumNetworks.jl](https://github.com/SciML/DeepEquilibriumNetworks.jl) | Navigation → Implicit Layer Deep Learning | Deep equilibrium networks. |
+| [DiffEqFlux.jl](https://github.com/SciML/DiffEqFlux.jl) | Navigation → Implicit Layer Deep Learning | Prebuilt implicit deep-learning architectures (Neural ODEs, …). |
+| [NeuralLyapunov.jl](https://github.com/SciML/NeuralLyapunov.jl) | Navigation → Implicit Layer Deep Learning | Search for neural Lyapunov functions. |
+
+### Inverse Problems / Estimation
+
+| Package | Where | Summary |
+| --- | --- | --- |
+| [CurveFit.jl](https://github.com/SciML/CurveFit.jl) | Navigation → Inverse Problems / Estimation | Least-squares and curve fitting on the CommonSolve interface. |
+| [DiffEqBayes.jl](https://github.com/SciML/DiffEqBayes.jl) | Navigation → Inverse Problems / Estimation | Simplified Bayesian estimation of DiffEq parameters. |
+| [DiffEqParamEstim.jl](https://github.com/SciML/DiffEqParamEstim.jl) | Navigation → Inverse Problems / Estimation | Simplified parameter-estimation loss functions. |
+| [SciMLSensitivity.jl](https://github.com/SciML/SciMLSensitivity.jl) | Navigation → Inverse Problems / Estimation | Local sensitivity, adjoints, and AD of solvers. |
+
+### Model Libraries and Importers
+
+| Package | Where | Summary |
+| --- | --- | --- |
+| [BaseModelica.jl](https://github.com/SciML/BaseModelica.jl) | Navigation → Model Libraries and Importers | Base Modelica importer for ModelingToolkit. |
+| [CellMLToolkit.jl](https://github.com/SciML/CellMLToolkit.jl) | Navigation → Model Libraries and Importers | CellML importer for ModelingToolkit. |
+| [DiffEqCallbacks.jl](https://github.com/SciML/DiffEqCallbacks.jl) | Navigation → Model Libraries and Importers | Premade callbacks for hybrid differential-equation models. |
+| [DiffEqPhysics.jl](https://github.com/SciML/DiffEqPhysics.jl) | Navigation → Model Libraries and Importers | Hamiltonian and physics-based DiffEq problem constructors. |
+| [FiniteStateProjection.jl](https://github.com/SciML/FiniteStateProjection.jl) | Navigation → Model Libraries and Importers | Finite-state projection of chemical master equations. |
+| [MathML.jl](https://github.com/SciML/MathML.jl) | Navigation → Model Libraries and Importers | MathML parser into Symbolics expressions. |
+| [ModelingToolkitNeuralNets.jl](https://github.com/SciML/ModelingToolkitNeuralNets.jl) | Navigation → Model Libraries and Importers | Neural-network blocks for universal differential equations in MTK. |
+| [ModelingToolkitStandardLibrary.jl](https://github.com/SciML/ModelingToolkitStandardLibrary.jl) | Navigation → Model Libraries and Importers | Standard component library for ModelingToolkit. |
+| [PubChem.jl](https://github.com/SciML/PubChem.jl) | Navigation → Model Libraries and Importers | PubChem metadata attached to Catalyst species. |
+| [Pyomo.jl](https://github.com/SciML/Pyomo.jl) | Navigation → Model Libraries and Importers | Pyomo interface via Symbolics.jl. |
+| [ReactionNetworkImporters.jl](https://github.com/SciML/ReactionNetworkImporters.jl) | Navigation → Model Libraries and Importers | BioNetGen and stoichiometry-matrix importers. |
+| [SBMLToolkit.jl](https://github.com/SciML/SBMLToolkit.jl) | Navigation → Model Libraries and Importers | SBML importer for Catalyst and ModelingToolkit. |
+
+### Modeling Languages
+
+| Package | Where | Summary |
+| --- | --- | --- |
+| [Catalyst.jl](https://github.com/SciML/Catalyst.jl) | Navigation → Modeling Languages | Chemical reaction networks and systems biology. |
+| [Corleone.jl](https://github.com/SciML/Corleone.jl) | Navigation → Modeling Languages | Optimal control with SciML. |
+| [DiffEqFinancial.jl](https://github.com/SciML/DiffEqFinancial.jl) | Navigation → Modeling Languages | Financial models (Heston, Black–Scholes, …) on DifferentialEquations. |
+| [ModelingToolkit.jl](https://github.com/SciML/ModelingToolkit.jl) | Navigation → Modeling Languages | Acausal symbolic modeling. |
+| [MomentClosure.jl](https://github.com/SciML/MomentClosure.jl) | Navigation → Modeling Languages | Moment-closure equations for chemical master equations and SDEs. |
+| [NBodySimulator.jl](https://github.com/SciML/NBodySimulator.jl) | Navigation → Modeling Languages | N-body, astrophysical, and molecular dynamics. |
+| [ParameterizedFunctions.jl](https://github.com/SciML/ParameterizedFunctions.jl) | Navigation → Modeling Languages | Simple DSL for defining differential equations. |
+| [ProcessSimulator.jl](https://github.com/SciML/ProcessSimulator.jl) | Navigation → Modeling Languages | Process simulation on ModelingToolkit. |
+
+### Numerical Utilities
+
+| Package | Where | Summary |
+| --- | --- | --- |
+| [BipartiteGraphs.jl](https://github.com/SciML/BipartiteGraphs.jl) | Navigation → Numerical Utilities | Bipartite graph types and utilities. |
+| [ConcreteStructs.jl](https://github.com/SciML/ConcreteStructs.jl) | Navigation → Numerical Utilities | Macros for concrete struct field types. |
+| [DataInterpolations.jl](https://github.com/SciML/DataInterpolations.jl) | Navigation → Numerical Utilities | 1D interpolation and smoothing. |
+| [DataInterpolationsND.jl](https://github.com/SciML/DataInterpolationsND.jl) | Navigation → Numerical Utilities | N-dimensional interpolation on hyperrectangles. |
+| [DiffEqNoiseProcess.jl](https://github.com/SciML/DiffEqNoiseProcess.jl) | Navigation → Numerical Utilities | Noise processes for SDEs and related solvers. |
+| [EllipsisNotation.jl](https://github.com/SciML/EllipsisNotation.jl) | Navigation → Numerical Utilities | `..` ellipsis indexing. |
+| [ExponentialUtilities.jl](https://github.com/SciML/ExponentialUtilities.jl) | Navigation → Numerical Utilities | Matrix exponentials, KIOPS, expmv, φ-functions. |
+| [FastAlmostBandedMatrices.jl](https://github.com/SciML/FastAlmostBandedMatrices.jl) | Navigation → Numerical Utilities | Almost-banded matrices (used by BoundaryValueDiffEq). |
+| [FastBroadcast.jl](https://github.com/SciML/FastBroadcast.jl) | Navigation → Numerical Utilities | `@..` broadcast that compiles to tight loops. |
+| [FindFirstFunctions.jl](https://github.com/SciML/FindFirstFunctions.jl) | Navigation → Numerical Utilities | Faster specialized `findfirst`. |
+| [FunctionWrappersWrappers.jl](https://github.com/SciML/FunctionWrappersWrappers.jl) | Navigation → Numerical Utilities | Double FunctionWrappers layer used in solver internals. |
+| [LHLFactorization.jl](https://github.com/SciML/LHLFactorization.jl) | Navigation → Numerical Utilities | Hessenberg reduction for families of shifted linear systems. |
+| [LightweightStats.jl](https://github.com/SciML/LightweightStats.jl) | Navigation → Numerical Utilities | Basic statistics with minimal dependencies. |
+| [MuladdMacro.jl](https://github.com/SciML/MuladdMacro.jl) | Navigation → Numerical Utilities | `@muladd` fused multiply-add rewriting. |
+| [PoissonRandom.jl](https://github.com/SciML/PoissonRandom.jl) | Navigation → Numerical Utilities | Fast Poisson random numbers. |
+| [PreallocationTools.jl](https://github.com/SciML/PreallocationTools.jl) | Navigation → Numerical Utilities | Caches compatible with automatic differentiation. |
+| [PureGebal.jl](https://github.com/SciML/PureGebal.jl) | Navigation → Numerical Utilities | Pure-Julia LAPACK xGEBAL-style matrix balancing. |
+| [PureKLU.jl](https://github.com/SciML/PureKLU.jl) | Navigation → Numerical Utilities | Pure-Julia KLU sparse LU, no SuiteSparse_jll. |
+| [PureUMFPACK.jl](https://github.com/SciML/PureUMFPACK.jl) | Navigation → Numerical Utilities | Pure-Julia UMFPACK-style sparse LU. |
+| [QuasiMonteCarlo.jl](https://github.com/SciML/QuasiMonteCarlo.jl) | Navigation → Numerical Utilities | Quasi-Monte Carlo sequences. |
+| [RespecializeParams.jl](https://github.com/SciML/RespecializeParams.jl) | Navigation → Numerical Utilities | Type-stable opaque parameter containers for solvers. |
+| [RootedTrees.jl](https://github.com/SciML/RootedTrees.jl) | Navigation → Numerical Utilities | Rooted trees and Runge–Kutta order conditions. |
+| [RuntimeGeneratedFunctions.jl](https://github.com/SciML/RuntimeGeneratedFunctions.jl) | Navigation → Numerical Utilities | Runtime-generated functions without world-age issues. |
+| [SparseBandedMatrices.jl](https://github.com/SciML/SparseBandedMatrices.jl) | Navigation → Numerical Utilities | Sparse banded matrices. |
+
+### PDE Solvers
+
+| Package | Where | Summary |
+| --- | --- | --- |
+| [DiffEqOperators.jl](https://github.com/SciML/DiffEqOperators.jl) | Navigation → PDE Solvers | Archived FDM operator library; prefer MethodOfLines. |
+| [FEniCS.jl](https://github.com/SciML/FEniCS.jl) | Navigation → PDE Solvers | FEniCS finite-element wrappers. |
+| [FiniteVolumeMethod.jl](https://github.com/SciML/FiniteVolumeMethod.jl) | Navigation → PDE Solvers | 2D finite-volume method for conservation laws. |
+| [FiniteVolumeMethod1D.jl](https://github.com/SciML/FiniteVolumeMethod1D.jl) | Navigation → PDE Solvers | 1D finite-volume method. |
+| [HighDimPDE.jl](https://github.com/SciML/HighDimPDE.jl) | Navigation → PDE Solvers | High-dimensional PDE solvers (Deep BSDE, Feynman–Kac). |
+| [MethodOfLines.jl](https://github.com/SciML/MethodOfLines.jl) | Navigation → PDE Solvers | Automated finite-difference discretization of PDESystem. |
+| [NeuralOperators.jl](https://github.com/SciML/NeuralOperators.jl) | Navigation → PDE Solvers | Fourier neural operators, DeepONets, and related operator learning. |
+| [NeuralPDE.jl](https://github.com/SciML/NeuralPDE.jl) | Navigation → PDE Solvers | Physics-informed neural network PDE solvers. |
+
+### Parameter Analysis
+
+| Package | Where | Summary |
+| --- | --- | --- |
+| [CatalystNetworkAnalysis.jl](https://github.com/SciML/CatalystNetworkAnalysis.jl) | Navigation → Parameter Analysis | Network-analysis algorithms on Catalyst reaction networks. |
+| [EasyModelAnalysis.jl](https://github.com/SciML/EasyModelAnalysis.jl) | Navigation → Parameter Analysis | High-level queries on simulation output. |
+| [GlobalSensitivity.jl](https://github.com/SciML/GlobalSensitivity.jl) | Navigation → Parameter Analysis | Global sensitivity analysis (Sobol, Morris, eFAST, …). |
+| [MinimallyDisruptiveCurves.jl](https://github.com/SciML/MinimallyDisruptiveCurves.jl) | Navigation → Parameter Analysis | Curves in parameter space that leave the solution nearly unchanged. |
+| [StructuralIdentifiability.jl](https://github.com/SciML/StructuralIdentifiability.jl) | Navigation → Parameter Analysis | Structural identifiability of ODE models. |
+
+### Symbolic Learning
+
+| Package | Where | Summary |
+| --- | --- | --- |
+| [DataDrivenDiffEq.jl](https://github.com/SciML/DataDrivenDiffEq.jl) | Navigation → Symbolic Learning | Data-driven dynamical systems and equation discovery. |
+| [SymbolicNumericIntegration.jl](https://github.com/SciML/SymbolicNumericIntegration.jl) | Navigation → Symbolic Learning | Symbolic-numeric integration. |
+
+### Symbolic Tools
+
+| Package | Where | Summary |
+| --- | --- | --- |
+| [FunctionProperties.jl](https://github.com/SciML/FunctionProperties.jl) | Navigation → Symbolic Tools | Detects function properties (branches, etc.) for compiler/AD optimizations. |
+| [ModelOrderReduction.jl](https://github.com/SciML/ModelOrderReduction.jl) | Navigation → Symbolic Tools | Automated model-order reduction on ModelingToolkit systems. |
+| [SymbolicAnalysis.jl](https://github.com/SciML/SymbolicAnalysis.jl) | Navigation → Symbolic Tools | Disciplined-programming property propagation for optimization. |
+| [SymbolicLimits.jl](https://github.com/SciML/SymbolicLimits.jl) | Navigation → Symbolic Tools | Symbolic limits and zero-equivalence of log-exp functions. |
+
+### Uncertainty Quantification
+
+| Package | Where | Summary |
+| --- | --- | --- |
+| [OptimalUncertaintyQuantification.jl](https://github.com/SciML/OptimalUncertaintyQuantification.jl) | Navigation → Uncertainty Quantification | Bounds on expectations without a fully specified input distribution. |
+| [PolyChaos.jl](https://github.com/SciML/PolyChaos.jl) | Navigation → Uncertainty Quantification | Polynomial chaos expansions. |
+| [SciMLExpectations.jl](https://github.com/SciML/SciMLExpectations.jl) | Navigation → Uncertainty Quantification | Fast expectations of equation solutions. |
+
+## Embedded in another docs site
+
+### Equation Solvers
+
+| Package | Where | Summary |
+| --- | --- | --- |
+| [DASKR.jl](https://github.com/SciML/DASKR.jl) | [DiffEqDocs](https://docs.sciml.ai/DiffEqDocs/stable/) | DASKR DAE solver wrapper. |
+| [DASSL.jl](https://github.com/SciML/DASSL.jl) | [DiffEqDocs](https://docs.sciml.ai/DiffEqDocs/stable/) | DASSL BDF DAE solver. |
+| [deSolveDiffEq.jl](https://github.com/SciML/deSolveDiffEq.jl) | [DiffEqDocs](https://docs.sciml.ai/DiffEqDocs/stable/) | R deSolve wrappers on the SciML interface. |
+| [DifferentialEquations.jl](https://github.com/SciML/DifferentialEquations.jl) | [DiffEqDocs](https://docs.sciml.ai/DiffEqDocs/stable/) | Umbrella DiffEq package; documented as DiffEqDocs. |
+| [GeometricIntegratorsDiffEq.jl](https://github.com/SciML/GeometricIntegratorsDiffEq.jl) | [DiffEqDocs](https://docs.sciml.ai/DiffEqDocs/stable/) | GeometricIntegrators.jl wrappers on the SciML interface. |
+| [ODEInterfaceDiffEq.jl](https://github.com/SciML/ODEInterfaceDiffEq.jl) | [DiffEqDocs](https://docs.sciml.ai/DiffEqDocs/stable/) | Hairer Fortran ODEInterface wrappers. |
+| [SciPyDiffEq.jl](https://github.com/SciML/SciPyDiffEq.jl) | [DiffEqDocs](https://docs.sciml.ai/DiffEqDocs/stable/) | SciPy ODE wrappers on the SciML interface. |
+| [SimpleBoundaryValueDiffEq.jl](https://github.com/SciML/SimpleBoundaryValueDiffEq.jl) | [DiffEqDocs](https://docs.sciml.ai/DiffEqDocs/stable/) | Minimal BVP solvers. |
+| [SimpleDiffEq.jl](https://github.com/SciML/SimpleDiffEq.jl) | [DiffEqDocs](https://docs.sciml.ai/DiffEqDocs/stable/) | Minimal no-cruft ODE solvers. |
+| [Sundials.jl](https://github.com/SciML/Sundials.jl) | [DiffEqDocs](https://docs.sciml.ai/DiffEqDocs/stable/) | CVODE, ARKODE, IDA, and KINSOL wrappers. |
+
+## Overview pages (no independent docs site yet)
+
+### Developer Documentation
+
+| Package | Where | Summary |
+| --- | --- | --- |
+| [SciMLTesting.jl](https://github.com/SciML/SciMLTesting.jl) | Overview pages | Shared GROUP-based test harness for SciML packages. |
+
+### Equation Solvers
+
+| Package | Where | Summary |
+| --- | --- | --- |
+| [BlackBoxOptim.jl](https://github.com/SciML/BlackBoxOptim.jl) | Overview pages | Derivative-free global/black-box optimization (OptimizationBBO). |
+| [ComplementaritySolve.jl](https://github.com/SciML/ComplementaritySolve.jl) | Overview pages | Complementarity problems with ChainRules-compatible gradients. |
+| [ParallelParticleSwarms.jl](https://github.com/SciML/ParallelParticleSwarms.jl) | Overview pages | GPU-accelerated particle-swarm optimization. |
+| [SpatialBranchAndBound.jl](https://github.com/SciML/SpatialBranchAndBound.jl) | Overview pages | Spatial branch-and-bound. |
+
+### Function Approximation
+
+| Package | Where | Summary |
+| --- | --- | --- |
+| [YOLOWeights.jl](https://github.com/SciML/YOLOWeights.jl) | Overview pages | Pinned, checksummed Ultralytics YOLO ONNX weights. |
+
+### High-Level Interfaces
+
+| Package | Where | Summary |
+| --- | --- | --- |
+| [SciMLPublic.jl](https://github.com/SciML/SciMLPublic.jl) | Overview pages | `@public` backport of Julia 1.11's `public` keyword. |
+
+### Model Libraries and Importers
+
+| Package | Where | Summary |
+| --- | --- | --- |
+| [CasADi.jl](https://github.com/SciML/CasADi.jl) | Overview pages | CasADi interface via PythonCall (fork of ichatzinikolaidis/CasADi.jl). |
+| [DiffEqProblemLibrary.jl](https://github.com/SciML/DiffEqProblemLibrary.jl) | Overview pages | Premade DiffEq problems for examples and testing. |
+| [PubChemReactions.jl](https://github.com/SciML/PubChemReactions.jl) | Overview pages | Reaction-network generation from PubChem data. |
+| [SBMLToolkitTestSuite.jl](https://github.com/SciML/SBMLToolkitTestSuite.jl) | Overview pages | Runner for the SBML Test Suite against SBMLToolkit. |
+
+### Numerical Utilities
+
+| Package | Where | Summary |
+| --- | --- | --- |
+| [BinaryHeaps.jl](https://github.com/SciML/BinaryHeaps.jl) | Overview pages | Invalidation-free binary heaps extracted from DataStructures.jl. |
+| [CommonWorldInvalidations.jl](https://github.com/SciML/CommonWorldInvalidations.jl) | Overview pages | Pre-invalidates common MethodError paths to cut latency. |
+| [FastPower.jl](https://github.com/SciML/FastPower.jl) | Overview pages | Faster, slightly less accurate floating-point power. |
+| [MaybeInplace.jl](https://github.com/SciML/MaybeInplace.jl) | Overview pages | Bang-bang macros that pick in-place vs out-of-place by array mutability. |
+| [ResettableStacks.jl](https://github.com/SciML/ResettableStacks.jl) | Overview pages | Stacks with `reset!` that avoid GC in solver internals. |
+| [SIMDRK.jl](https://github.com/SciML/SIMDRK.jl) | Overview pages | Generation of SIMD-compatible Runge–Kutta tableaus. |
+| [SimpleNorm.jl](https://github.com/SciML/SimpleNorm.jl) | Overview pages | `norm` without a LinearAlgebra/BLAS dependency. |
+| [SparseColumnPivotedQR.jl](https://github.com/SciML/SparseColumnPivotedQR.jl) | Overview pages | Rank-revealing column-pivoted Householder QR for SparseMatrixCSR. |
+| [SparseMatrixIdentification.jl](https://github.com/SciML/SparseMatrixIdentification.jl) | Overview pages | Sparse matrix structure identification. |
+| [SparseWithDenseRowColMatrices.jl](https://github.com/SciML/SparseWithDenseRowColMatrices.jl) | Overview pages | Sparse plus dense row/column matrices with Sherman–Morrison–Woodbury. |
+| [SpecializingFactorizations.jl](https://github.com/SciML/SpecializingFactorizations.jl) | Overview pages | Type-stable detection of dense-matrix structure with specialized factorizations. |
+| [TupleLU.jl](https://github.com/SciML/TupleLU.jl) | Overview pages | LU factorization on tuple-based small matrices. |
+
+### PDE Solvers
+
+| Package | Where | Summary |
+| --- | --- | --- |
+| [PDEBase.jl](https://github.com/SciML/PDEBase.jl) | Overview pages | Shared types and interface for ModelingToolkit PDE discretizers. |
+| [PDESystemLibrary.jl](https://github.com/SciML/PDESystemLibrary.jl) | Overview pages | Library of ModelingToolkit PDESystem examples. |
+
+### Plots and Visualization
+
+| Package | Where | Summary |
+| --- | --- | --- |
+| [DimensionalPlotRecipes.jl](https://github.com/SciML/DimensionalPlotRecipes.jl) | Overview pages | Plot recipes for high-dimensional numbers and reductions. |
+
+### Symbolic Learning
+
+| Package | Where | Summary |
+| --- | --- | --- |
+| [DataCollocations.jl](https://github.com/SciML/DataCollocations.jl) | Overview pages | Non-parametric collocation for smoothing timeseries and estimating derivatives. |
+
+## Learning resources / language bindings
+
+### Extra Resources
+
+| Package | Where | Summary |
+| --- | --- | --- |
+| [2025-JuliaCon-DifferentialEquations-Workshop](https://github.com/SciML/2025-JuliaCon-DifferentialEquations-Workshop) | Learning resources | JuliaCon 2025 DifferentialEquations workshop. |
+| [Catalyst_PLOS_COMPBIO_2023](https://github.com/SciML/Catalyst_PLOS_COMPBIO_2023) | Learning resources | Companion notebooks for the 2023 Catalyst PLOS Comp Bio paper. |
+| [GeiloInverseProblemWorkshop](https://github.com/SciML/GeiloInverseProblemWorkshop) | Learning resources | Geilo inverse-problems workshop notes. |
+| [Julia_Modeling_Workshop](https://github.com/SciML/Julia_Modeling_Workshop) | Learning resources | High-performance scientific modeling workshop. |
+| [ModelingToolkitWorkshop_JuliaCon2024](https://github.com/SciML/ModelingToolkitWorkshop_JuliaCon2024) | Learning resources | JuliaCon 2024 ModelingToolkit workshop materials. |
+| [Scientific_Modeling_Cheatsheet](https://github.com/SciML/Scientific_Modeling_Cheatsheet) | Learning resources | MATLAB / Python / Julia scientific-modeling cheatsheet. |
+| [SciMLBenchmarks.jl](https://github.com/SciML/SciMLBenchmarks.jl) | Learning resources | Benchmark sources; rendered output is SciMLBenchmarksOutput. |
+| [SciMLBook](https://github.com/SciML/SciMLBook) | Learning resources | Parallel Computing and Scientific Machine Learning lecture notes (MIT 18.337). |
+
+### Language Bindings
+
+| Package | Where | Summary |
+| --- | --- | --- |
+| [diffeqpy](https://github.com/SciML/diffeqpy) | Learning resources | Python bindings for DifferentialEquations.jl. |
+| [diffeqr](https://github.com/SciML/diffeqr) | Learning resources | R bindings for DifferentialEquations.jl. |
+| [juliatorch](https://github.com/SciML/juliatorch) | Learning resources | Wrap Julia functions as PyTorch autograd functions. |
+
+## Not a user-facing package
+
+### Infrastructure
+
+| Package | Where | Summary |
+| --- | --- | --- |
+| [.github](https://github.com/SciML/.github) | Not documented as a package | Organization-wide GitHub Actions and metadata. |
+| [demo-repository](https://github.com/SciML/demo-repository) | Not documented as a package | GitHub demo repository, not a SciML package. |
+| [LinearSolveAutotuneResults.jl](https://github.com/SciML/LinearSolveAutotuneResults.jl) | Not documented as a package | Stored LinearSolve autotune results, not a solver package. |
+| [ModelDiscovery.jl](https://github.com/SciML/ModelDiscovery.jl) | Not documented as a package | Empty placeholder repository. |
+| [OptimalUncertaintyQuantification-DEV.jl](https://github.com/SciML/OptimalUncertaintyQuantification-DEV.jl) | Not documented as a package | Development duplicate of OptimalUncertaintyQuantification.jl. |
+| [PropertyModels.jl](https://github.com/SciML/PropertyModels.jl) | Not documented as a package | Empty placeholder repository. |
+| [sciml.ai](https://github.com/SciML/sciml.ai) | Not documented as a package | Organization website. |
+| [SciMLAssets](https://github.com/SciML/SciMLAssets) | Not documented as a package | Shared website/assets. |
+| [SciMLDocs](https://github.com/SciML/SciMLDocs) | Not documented as a package | This documentation aggregator (Home in the nav). |

--- a/docs/src/highlevels/package_index.md
+++ b/docs/src/highlevels/package_index.md
@@ -54,6 +54,7 @@ for those docs rather than a second copy in the navigation bar.
 
 | Package | Where | Summary |
 | --- | --- | --- |
+| [Corleone.jl](https://github.com/SciML/Corleone.jl) | Navigation → Equation Solvers | Optimal control with SciML. |
 | [DiffEqDocs.jl](https://github.com/SciML/DiffEqDocs.jl) | Navigation → Equation Solvers | DifferentialEquations.jl documentation (umbrella for the DiffEq solvers). |
 | [DifferenceEquations.jl](https://github.com/SciML/DifferenceEquations.jl) | Navigation → Equation Solvers | Deterministic and stochastic difference equations and state-space likelihoods. |
 | [Evolutionary.jl](https://github.com/SciML/Evolutionary.jl) | Navigation → Equation Solvers | Evolutionary and genetic algorithms. |
@@ -120,6 +121,7 @@ for those docs rather than a second copy in the navigation bar.
 | [BaseModelica.jl](https://github.com/SciML/BaseModelica.jl) | Navigation → Model Libraries and Importers | Base Modelica importer for ModelingToolkit. |
 | [CellMLToolkit.jl](https://github.com/SciML/CellMLToolkit.jl) | Navigation → Model Libraries and Importers | CellML importer for ModelingToolkit. |
 | [DiffEqCallbacks.jl](https://github.com/SciML/DiffEqCallbacks.jl) | Navigation → Model Libraries and Importers | Premade callbacks for hybrid differential-equation models. |
+| [DiffEqFinancial.jl](https://github.com/SciML/DiffEqFinancial.jl) | Navigation → Model Libraries and Importers | Financial models (Heston, Black–Scholes, …) on DifferentialEquations. |
 | [DiffEqPhysics.jl](https://github.com/SciML/DiffEqPhysics.jl) | Navigation → Model Libraries and Importers | Hamiltonian and physics-based DiffEq problem constructors. |
 | [FiniteStateProjection.jl](https://github.com/SciML/FiniteStateProjection.jl) | Navigation → Model Libraries and Importers | Finite-state projection of chemical master equations. |
 | [MathML.jl](https://github.com/SciML/MathML.jl) | Navigation → Model Libraries and Importers | MathML parser into Symbolics expressions. |
@@ -135,8 +137,6 @@ for those docs rather than a second copy in the navigation bar.
 | Package | Where | Summary |
 | --- | --- | --- |
 | [Catalyst.jl](https://github.com/SciML/Catalyst.jl) | Navigation → Modeling Languages | Chemical reaction networks and systems biology. |
-| [Corleone.jl](https://github.com/SciML/Corleone.jl) | Navigation → Modeling Languages | Optimal control with SciML. |
-| [DiffEqFinancial.jl](https://github.com/SciML/DiffEqFinancial.jl) | Navigation → Modeling Languages | Financial models (Heston, Black–Scholes, …) on DifferentialEquations. |
 | [ModelingToolkit.jl](https://github.com/SciML/ModelingToolkit.jl) | Navigation → Modeling Languages | Acausal symbolic modeling. |
 | [MomentClosure.jl](https://github.com/SciML/MomentClosure.jl) | Navigation → Modeling Languages | Moment-closure equations for chemical master equations and SDEs. |
 | [NBodySimulator.jl](https://github.com/SciML/NBodySimulator.jl) | Navigation → Modeling Languages | N-body, astrophysical, and molecular dynamics. |

--- a/docs/src/highlevels/parameter_analysis.md
+++ b/docs/src/highlevels/parameter_analysis.md
@@ -1,5 +1,11 @@
 # Parameter Analysis Utilities
 
+## EasyModelAnalysis.jl: High-Level Queries on Simulation Output
+
+[EasyModelAnalysis.jl](https://github.com/SciML/EasyModelAnalysis.jl) wraps common analysis
+questions — first crossing times, event probabilities, parameter sensitivities — so they
+can be asked directly of a simulated model without assembling the underlying solver calls.
+
 ## GlobalSensitivity.jl: Global Sensitivity Analysis
 
 Derivatives calculate the local sensitivity of a model, i.e. the change in the simulation's outcome if
@@ -39,6 +45,12 @@ For more information on what StructuralIdentifiability.jl is all about, see the
 
 [MinimallyDisruptiveCurves.jl](https://github.com/SciML/MinimallyDisruptiveCurves.jl) is a library for
 finding relationships between parameters of models, finding the curves on which the solution is constant.
+
+## CatalystNetworkAnalysis.jl: Reaction Network Analysis
+
+[CatalystNetworkAnalysis.jl](https://github.com/SciML/CatalystNetworkAnalysis.jl) analyzes Catalyst
+reaction networks for dynamical properties such as multistationarity, concentration robustness,
+and persistence.
 
 # Third-Party Libraries to Note
 

--- a/docs/src/highlevels/partial_differential_equation_solvers.md
+++ b/docs/src/highlevels/partial_differential_equation_solvers.md
@@ -52,6 +52,19 @@ defining finite difference operators to easily perform manual FDM semi-discretiz
 of partial differential equations. This library is fairly incomplete and most cases
 should receive better performance using MethodOflines.jl.
 
+## FiniteVolumeMethod.jl and FiniteVolumeMethod1D.jl: Finite Volume Discretizations
+
+[FiniteVolumeMethod.jl](https://github.com/SciML/FiniteVolumeMethod.jl) solves two-dimensional
+conservation laws with the finite volume method.
+[FiniteVolumeMethod1D.jl](https://github.com/SciML/FiniteVolumeMethod1D.jl) is the corresponding
+one-dimensional implementation.
+
+## PDEBase.jl and PDESystemLibrary.jl
+
+[PDEBase.jl](https://github.com/SciML/PDEBase.jl) holds shared types for ModelingToolkit
+`PDESystem` discretizers. [PDESystemLibrary.jl](https://github.com/SciML/PDESystemLibrary.jl)
+is a library of example `PDESystem`s.
+
 # Third-Party Libraries to Note
 
 A more exhaustive list of Julia PDE packages can be found here: https://github.com/JuliaPDE/SurveyofPDEPackages

--- a/docs/src/highlevels/symbolic_tools.md
+++ b/docs/src/highlevels/symbolic_tools.md
@@ -35,3 +35,20 @@ library and rule-based rewriting language on which Symbolics.jl is developed. Sy
 standardized type and rule definitions built using SymbolicUtils.jl. However, if non-standard
 types are required, such as [symbolic computing over Fock algebras](https://github.com/qojulia/QuantumCumulants.jl),
 then SymbolicUtils.jl is the library from which the new symbolic types can be implemented.
+
+## SymbolicAnalysis.jl: Function Property Propagation for Optimization
+
+[SymbolicAnalysis.jl](https://github.com/SciML/SymbolicAnalysis.jl) implements disciplined
+programming on Symbolics.jl expressions, propagating convexity and related properties for
+optimization.
+
+## SymbolicLimits.jl: Symbolic Limits
+
+[SymbolicLimits.jl](https://github.com/SciML/SymbolicLimits.jl) computes symbolic limits,
+including a reduction used for zero-equivalence of log-exp functions.
+
+## FunctionProperties.jl: Compiler-Facing Function Queries
+
+[FunctionProperties.jl](https://github.com/SciML/FunctionProperties.jl) answers questions
+about Julia functions that the symbolic-numeric compilers need, for example whether `f`
+contains branches that would block a given AD or simplification path.

--- a/docs/src/highlevels/uncertainty_quantification.md
+++ b/docs/src/highlevels/uncertainty_quantification.md
@@ -27,6 +27,12 @@ expectations without requiring the propagation of uncertainties through a solver
 effectively performing the adjoint of uncertainty quantification and being much more
 efficient in the process.
 
+## OptimalUncertaintyQuantification.jl: Bounds Without a Fully Specified Distribution
+
+[OptimalUncertaintyQuantification.jl](https://github.com/SciML/OptimalUncertaintyQuantification.jl)
+computes bounds on expectations of quantities of interest when the input probability distribution
+is only partially known.
+
 # Third-Party Libraries to Note
 
 ## Measurements.jl: Automated Linear Error Propagation

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -20,7 +20,8 @@ features many of the highest performance and parallel implementations one can fi
   - Want to see our code? Check out [the SciML GitHub organization](https://github.com/SciML).
 
 And for diving into the details, use the bar on the top to navigate to the submodule of
-interest!
+interest! The complete list of SciML repositories and where each one is documented is
+in the [Package Index](@ref package_index).
 
 ## Reproducibility
 

--- a/test/package_coverage.jl
+++ b/test/package_coverage.jl
@@ -1,0 +1,88 @@
+function strip_julia_comments(s::AbstractString)
+    out = IOBuffer()
+    i = firstindex(s)
+    n = lastindex(s)
+    while i <= n
+        if i < n && s[i] == '#' && s[nextind(s, i)] == '='
+            depth = 1
+            i = nextind(s, i, 2)
+            while i < n && depth > 0
+                nxt = nextind(s, i)
+                if s[i] == '#' && s[nxt] == '='
+                    depth += 1
+                    i = nextind(s, i, 2)
+                elseif s[i] == '=' && s[nxt] == '#'
+                    depth -= 1
+                    i = nextind(s, i, 2)
+                else
+                    i = nxt
+                end
+            end
+        elseif s[i] == '#'
+            while i <= n && s[i] != '\n'
+                i = nextind(s, i)
+            end
+        else
+            print(out, s[i])
+            i = nextind(s, i)
+        end
+    end
+    return String(take!(out))
+end
+
+@testset "Package inventory coverage" begin
+    root = pkgdir(SciMLDocs)
+    inventory_path = joinpath(root, "docs", "package_inventory.toml")
+    aggregate_path = joinpath(root, "docs", "make_aggregate.jl")
+    index_path = joinpath(root, "docs", "src", "highlevels", "package_index.md")
+    make_path = joinpath(root, "docs", "make.jl")
+
+    inventory = TOML.parsefile(inventory_path)["packages"]
+    aggregate = read(aggregate_path, String)
+    index = read(index_path, String)
+    make = read(make_path, String)
+
+    @test !isempty(inventory)
+    @test occursin("highlevels/package_index.md", make)
+
+    missing_from_index = String[]
+    missing_from_dropdown = String[]
+    inventoried_dropdown = Set{String}()
+    for (repo, meta) in inventory
+        occursin(repo, index) || push!(missing_from_index, repo)
+        dropdown = get(meta, "dropdown", nothing)
+        if dropdown !== nothing
+            push!(inventoried_dropdown, dropdown)
+            occursin("\"" * dropdown * "\"", aggregate) ||
+                push!(missing_from_dropdown, dropdown)
+        end
+    end
+    @test missing_from_index == String[]
+    @test missing_from_dropdown == String[]
+
+    ext_start = findfirst("external_urls = Dict(", aggregate)
+    ext_stop = findfirst("docs = Any[", aggregate)
+    @test ext_start !== nothing && ext_stop !== nothing
+    ext_block = aggregate[first(ext_start):first(ext_stop)]
+    third_party = Set{String}()
+    for m in eachmatch(r"\"([A-Za-z0-9]+)\"\s*=>\s*\"https://", ext_block)
+        push!(third_party, m.captures[1])
+    end
+
+    docs_start = findfirst("docsmodules = [", aggregate)
+    docs_stop = findfirst("fixnames = Dict", aggregate)
+    @test docs_start !== nothing && docs_stop !== nothing
+    docsmodules = strip_julia_comments(aggregate[first(docs_start):first(docs_stop)])
+
+    uninventoried = String[]
+    seen = Set{String}()
+    for m in eachmatch(r"\"([A-Za-z][A-Za-z0-9]*)\"(?!\s*=>)", docsmodules)
+        name = m.captures[1]
+        name in seen && continue
+        push!(seen, name)
+        name in third_party && continue
+        name in inventoried_dropdown && continue
+        push!(uninventoried, name)
+    end
+    @test uninventoried == String[]
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,11 @@
 using Test
 using ExplicitImports
 using SciMLDocs
+using TOML
 
 @testset "ExplicitImports" begin
     @test check_no_implicit_imports(SciMLDocs) === nothing
     @test check_no_stale_explicit_imports(SciMLDocs) === nothing
 end
+
+include("package_coverage.jl")


### PR DESCRIPTION
**Please ignore this PR until it is reviewed by @ChrisRackauckas.**

## What changed and why

Every non-archived SciML repository now has an explicit place in SciMLDocs.

- **Top navigation (MultiDocumenter dropdown):** 34 packages that already publish Documenter `gh-pages` were added to `docs/make_aggregate.jl` in the matching category. This is the same list the docs.sciml.ai bar uses.
- **Embedded docs:** solver packages whose API pages already live in DiffEqDocs (Sundials, DASKR, DASSL, ODEInterfaceDiffEq, SimpleDiffEq, SimpleBoundaryValueDiffEq, SciPyDiffEq, deSolveDiffEq, GeometricIntegratorsDiffEq, and DifferentialEquations.jl itself) stay there, matching OrdinaryDiffEq. They are not given a second nav entry that would clone empty or missing `gh-pages`.
- **Package index:** [docs/src/highlevels/package_index.md](docs/src/highlevels/package_index.md) lists all 169 non-archived SciML repos plus the three archived docs sites still in the nav (DiffEqDevDocs, DiffEqOperators, SciMLTutorialsOutput), with a one-line summary and where the docs live.
- **Overview pages:** high-level sections were filled in for packages that were in the nav but missing from the narrative, and for the newly added ones.
- **Inventory test:** `docs/package_inventory.toml` is the machine-readable catalog. `test/package_coverage.jl` checks that every inventoried repo appears in the package index and that every `dropdown = true` name is actually quoted in `make_aggregate.jl`.

MomentClosure.jl is now treated as a SciML first-party package (the repo has been transferred). FiniteStateProjection.jl clones from SciML rather than kaandocal. BlackBoxOptim / Evolutionary GitHub links in the overview now point at SciML.

Packages **without** Documenter `gh-pages` were not added to the dropdown. Putting them there would fail the aggregate clone. They are in the package index and, where they are user-facing, in the overview pages.

## Dropdown additions

Modeling: Corleone, ProcessSimulator, MomentClosure, DiffEqFinancial, DiffEqPhysics, PubChem, Pyomo, MathML, FunctionProperties

Solvers: Evolutionary, NeuralLinearSolve, SteadyStateDiffEq, OrdinaryDiffEqOperatorSplitting, IRKGaussLegendre, MATLABDiffEq, QuantumNLDiffEq

Analysis: MinimallyDisruptiveCurves, CatalystNetworkAnalysis, OptimalUncertaintyQuantification

Developer tools: FastAlmostBandedMatrices, FastBroadcast, FunctionWrappersWrappers, LHLFactorization, LightweightStats, PureGebal, PureKLU, PureUMFPACK, RootedTrees, SparseBandedMatrices, RespecializeParams, ConcreteStructs, SciMLIterators, Static, OrgMaintenanceScripts

## Verification

`julia --project -e 'using Pkg; Pkg.test()'` on this branch:

```
Test Summary:   | Pass  Total  Time
ExplicitImports |    2      2  1.5s
Test Summary:              | Pass  Total  Time
Package inventory coverage |    7      7  0.3s
     Testing SciMLDocs tests passed
```

`typos` over the changed files: clean.

Julia files formatted with Runic.jl.

The coverage test was written against the inventory; removing a `dropdown` name from `make_aggregate.jl` makes `missing_from_dropdown` non-empty.

## What was not verified

- **Aggregate MultiDocumenter build** (clones every package `gh-pages` and deploys to S3). That is the self-hosted GPU `aggregate` job; it was not run locally.
- **Home Documenter `makedocs` / linkcheck.** New links are GitHub URLs, but CI still needs to confirm `@ref package_index` and linkcheck.
- GPU / allowed-to-fail jobs do not apply.

## Reviewer notes

- Adding 34 clones will make the 6-hour aggregate job slower and more sensitive to a single broken `gh-pages`. All 34 were checked to have a Documenter-shaped `gh-pages` tree (`versions.js` and/or `dev`/`stable`).
- Some of those sites only have `dev`, not `stable`. Search indexes `stable` only, so they may not appear in global search until they tag.
- OptimalUncertaintyQuantification-DEV.jl is recorded as infra (dev duplicate), not given a nav slot.
- CasADi.jl is a fork and has no `gh-pages`; it is overview-only.

🤖 Generated with Grok Build TUI (model: grok-4.6)
Session: local Grok session `01a0479b-c972-7040-a026-2c6749f9294f` (no public conversation URL)