### PR TITLE
Format CommercialSupportComponent with Runic 1.10

### DIFF
--- a/docs/CommercialSupportComponent.jl
+++ b/docs/CommercialSupportComponent.jl
@@ -29,12 +29,12 @@ PRODUCTNAME_IMAGE_LINK = [
 function MultiDocumenter.render(c::ProductsUsedComponent, doc, thispage, prettyurls)
     strings = [
         MultiDocumenter.@htl """
-            <li>
-                <a href=$(product.link) class="nav-link nav-item">
-                    $(product.product)
-                </a>
-            </li>
-            """ for product in PRODUCTNAME_IMAGE_LINK
+        <li>
+            <a href=$(product.link) class="nav-link nav-item">
+                $(product.product)
+            </a>
+        </li>
+        """ for product in PRODUCTNAME_IMAGE_LINK
     ]
 
     return MultiDocumenter.@htl """


### PR DESCRIPTION
**Please ignore this PR until it is reviewed by @ChrisRackauckas.**

## What changed and why

Runic 1.10.0 changed indentation for multiline expressions inside generators. SciMLDocs resolves the formatter's latest 1.x release, so the repository-wide format check began failing on the pre-existing `MultiDocumenter.@htl` generator after Runic 1.10 was released.

This applies Runic's six-line dedent and nothing else. It is a mechanical whitespace-only PR, separate from the documentation build behavior fix in https://github.com/SciML/SciMLDocs/pull/359.

## Failing before

Exact Runic 1.10 check on clean `main`:

```text
docs/CommercialSupportComponent.jl ... ✖
@@ -29,12 +29,12 @@
-            <li>
+        <li>
...
Process completed with exit code 1.
```

The same file passes Runic 1.9.0. Runic 1.10.0 was released after the last passing main check and includes the generator-indentation change, so there is no SciMLDocs commit to bisect.

## Passing after

```text
julia +1.12 --project=@runic -e 'using Runic; exit(Runic.main(ARGS))' -- --check --extensions=jl .
# exit 0

typos docs/CommercialSupportComponent.jl
# exit 0

GROUP=QA julia +1.11 --project -e 'using Pkg; Pkg.test()'
Test Summary:   | Pass  Total
ExplicitImports |    2      2
Test Summary:              | Pass  Total
Package inventory coverage |    7      7
Testing SciMLDocs tests passed

git diff --check
# exit 0
```

## What was not verified

The aggregate documentation site was not rebuilt for this PR. The edit changes only source indentation inside an HTML template; aggregate behavior is covered by the documentation CI job.

## Reviewer notes

This intentionally contains no behavior changes or unrelated cleanup. Runic 1.10 release: https://github.com/fredrikekre/Runic.jl/releases/tag/v1.10.0. Relevant formatter change: https://github.com/fredrikekre/Runic.jl/commit/8345856ec3c4f4d24c0ae50cf9d01f20aa6e1719.

🤖 Generated with Codex CLI 0.151.0 (model: gpt-5.6-sol; session: 01a04f9f-6376-7ee1-87a6-41698958926f, local session with no public conversation URL)
