### PR TITLE
Fix Documentation concurrency cancellation and drop schedule to daily

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -1,10 +1,13 @@
 name: "Documentation"
 
 on:
-  # Rebuild every 6 hours so downstream package gh-pages updates propagate to docs.sciml.ai
+  # Rebuild daily so downstream package gh-pages updates propagate to docs.sciml.ai
   # (restores the scheduled deploy that Buildkite ran before the 2026-03 GHA migration).
+  # Daily (not every 6h): the full+aggregate build takes >6h, so a 6h schedule
+  # guarantees overlap. With cancel-in-progress enabled for main, each new
+  # schedule cancelled the previous build and nothing ever finished.
   schedule:
-    - cron: '0 */6 * * *'
+    - cron: '0 0 * * *'
   workflow_dispatch:
   pull_request:
     branches:
@@ -15,7 +18,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch || github.ref != 'refs/tags/v*' }}
+  # Only cancel PR runs. The previous `|| github.ref != 'refs/tags/v*'` was
+  # always true (`v*` is a literal, not a glob), so every schedule cancelled
+  # the in-progress main build and docs.sciml.ai never deployed.
+  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch && github.ref_type != 'tag' }}
 
 jobs:
   docs:


### PR DESCRIPTION
Please ignore this PR until it is reviewed by @ChrisRackauckas.

## What changed and why

Fixes the `Documentation` workflow so `docs.sciml.ai` can deploy again. The `cancel-in-progress` expression used `|| github.ref != 'refs/tags/v*'`, which is always true (literal, not a glob), so every 6h schedule cancelled the in-progress `main` build. With build times >6h, there has been no successful run since 2026-07-06. This changes the condition to only cancel off-default-branch/non-tag runs and drops the schedule from every 6h to daily to leave headroom.

Minimal on purpose: no `DOCUMENTER_KEY` / permissions changes from #361.

## Verification

```text
$ git diff --check
(exit 0)

$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/Documentation.yml')); print('YAML parses OK')"
YAML parses OK

$ typos .github/workflows/Documentation.yml
(exit 0)

$ actionlint .github/workflows/Documentation.yml
only pre-existing custom-runner-label warnings for `gpu` / `high-memory` (same as #359 noted as allowed)
```

Inspected runs via API:
- Last `Documentation` success: https://github.com/SciML/SciMLDocs/actions/runs/28794579537 (2026-07-06)
- Example cancelled run with annotation `Canceling since a higher priority waiting request for Documentation-refs/heads/main exists`: https://github.com/SciML/SciMLDocs/actions/runs/34547058856

## What was not verified

- Did not run `docs/make.jl` or the aggregate S3 deploy locally (needs the `gpu, high-memory` self-hosted runner, multi-hour build, AWS credentials).
- Did not verify runner capacity for the currently queued runs (https://github.com/SciML/SciMLDocs/actions/runs/34569561462 queued 2h+, https://github.com/SciML/SciMLDocs/actions/runs/34471979283 queued 21h+). If the queue is a runner shortage rather than just concurrency, the first daily run after merge will confirm.

## Reviewer notes

- Cron choice `0 0 * * *` is arbitrary daily midnight UTC; pick another hour if you prefer to spread load.
- If you want 6h freshness back later, builds must first get reliably under ~5h, otherwise the overlap returns.

## Links

- Last successful scheduled deploy: https://github.com/SciML/SciMLDocs/actions/runs/28794579537
- Cancelled example: https://github.com/SciML/SciMLDocs/actions/runs/34547058856
- Prior unmerged diagnosis (#361): https://github.com/SciML/SciMLDocs/pull/361
- OOM runner fix (#359): https://github.com/SciML/SciMLDocs/pull/359

🤖 Generated with [OpenCode](https://opencode.ai) (model: opencode/muse-spark-1.3-contributor-free)
Session: local sandbox tmp_20260911_053008_15679 (no public conversation URL)
